### PR TITLE
Add a "Notes" filed on props

### DIFF
--- a/forecast-app/app/forecasts/record/[year]/record-forecast-form.tsx
+++ b/forecast-app/app/forecasts/record/[year]/record-forecast-form.tsx
@@ -54,7 +54,12 @@ export function RecordForecastForm({ prop }: { prop: VProp }) {
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
         <div className="grid grid-cols-6 grid-flow-col content-end gap-y-2 gap-x-1">
-          <span className="col-span-4 text-sm mr-2">{prop.prop_text}</span>
+          <div className="col-span-4 text-sm mr-2 flex flex-col">
+            <span>{prop.prop_text}</span>
+            <span className="text-muted-foreground italic">
+              {prop.prop_notes}
+            </span>
+          </div>
           <FormField
             control={form.control}
             name="forecast"

--- a/forecast-app/components/forms/create-edit-prop-form.tsx
+++ b/forecast-app/components/forms/create-edit-prop-form.tsx
@@ -34,6 +34,10 @@ import {
 
 const formSchema = z.object({
   text: z.string().min(8).max(1000),
+  notes: z.preprocess(
+    (arg) => (arg === "" ? null : arg),
+    z.string().max(1000).nullable(),
+  ),
   category_id: z.coerce.number(),
   year: z.coerce.number(),
 });
@@ -54,6 +58,7 @@ export function CreateEditPropForm(
     resolver: zodResolver(formSchema),
     defaultValues: {
       text: initialProp?.prop_text,
+      notes: initialProp?.prop_notes || undefined,
       category_id: initialProp?.category_id,
       year: initialProp?.year,
     },
@@ -74,7 +79,6 @@ export function CreateEditPropForm(
     setLoading(true);
     try {
       if (initialProp) {
-        // If initialProp was set, we're editing an existing prop.
         await updateProp({
           id: initialProp.prop_id,
           prop: { ...values },
@@ -132,6 +136,23 @@ export function CreateEditPropForm(
               <FormLabel>Prop</FormLabel>
               <FormControl>
                 <Textarea {...field} className="text-sm min-h-20" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="notes"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Notes</FormLabel>
+              <FormControl>
+                <Textarea
+                  {...field}
+                  value={field.value ?? undefined}
+                  className="text-sm min-h-20"
+                />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/forecast-app/components/tables/prop-table/columns.tsx
+++ b/forecast-app/components/tables/prop-table/columns.tsx
@@ -3,6 +3,7 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { VProp } from "@/types/db_types";
 import { ActionDropdown } from "./action-dropdown";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 
 export function getColumns(
   allowResolutionEdits: boolean,
@@ -14,12 +15,21 @@ export function getColumns(
       meta: { className: "min-w-[90%]" },
       cell: ({ row }) => {
         return (
-          <div className="flex flex-col justify-start items-start gap-1">
-            <div className="text-xs text-muted-foreground">
-              {row.original.category_name}
-            </div>
-            <div>{row.original.prop_text}</div>
-          </div>
+          <Popover>
+            <PopoverTrigger>
+              <div className="flex flex-col justify-start items-start gap-1">
+                <div className="text-xs text-muted-foreground">
+                  {row.original.category_name}
+                </div>
+                <div className="text-left">{row.original.prop_text}</div>
+              </div>
+            </PopoverTrigger>
+            <PopoverContent>
+              <p className="text-muted-foreground text-sm">{row.original.category_name}</p>
+              <p>{row.original.prop_text}</p>
+              <p className="text-muted-foreground text-sm italic">{row.original.prop_notes}</p>
+            </PopoverContent>
+          </Popover>
         );
       },
     },

--- a/forecast-app/components/tables/prop-table/columns.tsx
+++ b/forecast-app/components/tables/prop-table/columns.tsx
@@ -3,7 +3,11 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { VProp } from "@/types/db_types";
 import { ActionDropdown } from "./action-dropdown";
-import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 
 export function getColumns(
   allowResolutionEdits: boolean,
@@ -25,9 +29,13 @@ export function getColumns(
               </div>
             </PopoverTrigger>
             <PopoverContent>
-              <p className="text-muted-foreground text-sm">{row.original.category_name}</p>
+              <p className="text-muted-foreground text-sm">
+                {row.original.category_name}
+              </p>
               <p>{row.original.prop_text}</p>
-              <p className="text-muted-foreground text-sm italic">{row.original.prop_notes}</p>
+              <p className="text-muted-foreground text-sm italic">
+                {row.original.prop_notes}
+              </p>
             </PopoverContent>
           </Popover>
         );

--- a/forecast-app/lib/db_actions/props.ts
+++ b/forecast-app/lib/db_actions/props.ts
@@ -46,7 +46,7 @@ export async function unresolveProp({ propId }: { propId: number }): Promise<voi
 }
 
 export async function getPropYears(): Promise<number[]> {
-  const rows = await db.selectFrom('v_props').select('year').distinct().execute();
+  const rows = await db.selectFrom('v_props').select('year').distinct().orderBy('year', 'desc').execute();
   return rows.map(row => row.year);
 }
 

--- a/forecast-app/migrations/1732464326543_alter-props-table-add-notes-col.ts
+++ b/forecast-app/migrations/1732464326543_alter-props-table-add-notes-col.ts
@@ -1,0 +1,15 @@
+import type { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+	await db.schema
+		.alterTable('props')
+		.addColumn('notes', 'text')
+		.execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await db.schema
+		.alterTable('props')
+		.dropColumn('notes')
+		.execute()
+}

--- a/forecast-app/migrations/1732464326543_alter-props-table-add-notes-col.ts
+++ b/forecast-app/migrations/1732464326543_alter-props-table-add-notes-col.ts
@@ -1,10 +1,49 @@
-import type { Kysely } from 'kysely'
+import { sql, type Kysely } from 'kysely'
 
 export async function up(db: Kysely<any>): Promise<void> {
+	// Create the new columns.
 	await db.schema
 		.alterTable('props')
 		.addColumn('notes', 'text')
 		.execute()
+	// Update v_props view.
+	await db.schema.dropView('v_props').execute();
+	await db.schema.createView('v_props').as(
+		db.selectFrom('props')
+			.innerJoin('categories', 'props.category_id', 'categories.id')
+			.leftJoin('resolutions', 'props.id', 'resolutions.prop_id')
+			.select([
+				'categories.id as category_id',
+				'categories.name as category_name',
+				'props.id as prop_id',
+				'props.text as prop_text',
+				'props.notes as prop_notes',
+				'props.year',
+				'resolutions.resolution',
+			])
+	).execute()
+	// Update the v_forecasts view.
+	await db.schema.dropView('v_forecasts').execute();
+	await db.schema.createView('v_forecasts').as(
+		db.selectFrom('users')
+			.innerJoin('forecasts', 'users.id', 'forecasts.user_id')
+			.innerJoin('props', 'forecasts.prop_id', 'props.id')
+			.innerJoin('categories', 'props.category_id', 'categories.id')
+			.leftJoin('resolutions', 'props.id', 'resolutions.prop_id')
+			.select([
+				'users.id as user_id',
+				'users.name as user_name',
+				'categories.id as category_id',
+				'categories.name as category_name',
+				'props.id as prop_id',
+				'props.text as prop_text',
+				'props.notes as prop_notes',
+				'props.year',
+				'forecasts.forecast',
+				'resolutions.resolution',
+				sql<number>`power(resolutions.resolution::integer - forecasts.forecast, 2)`.as("score"),
+			])
+	).execute()
 }
 
 export async function down(db: Kysely<any>): Promise<void> {
@@ -12,4 +51,40 @@ export async function down(db: Kysely<any>): Promise<void> {
 		.alterTable('props')
 		.dropColumn('notes')
 		.execute()
+	// Restore the old v_props view.
+	await db.schema.dropView('v_props').execute();
+	await db.schema.createView('v_props').orReplace().as(
+		db.selectFrom('props')
+			.innerJoin('categories', 'props.category_id', 'categories.id')
+			.leftJoin('resolutions', 'props.id', 'resolutions.prop_id')
+			.select([
+				'categories.id as category_id',
+				'categories.name as category_name',
+				'props.id as prop_id',
+				'props.text as prop_text',
+				'props.year',
+				'resolutions.resolution',
+			])
+	).execute()
+	// Restore the old v_forecasts view.
+	await db.schema.dropView('v_forecasts').execute();
+	await db.schema.createView('v_forecasts').orReplace().as(
+		db.selectFrom('users')
+			.innerJoin('forecasts', 'users.id', 'forecasts.user_id')
+			.innerJoin('props', 'forecasts.prop_id', 'props.id')
+			.innerJoin('categories', 'props.category_id', 'categories.id')
+			.leftJoin('resolutions', 'props.id', 'resolutions.prop_id')
+			.select([
+				'users.id as user_id',
+				'users.name as user_name',
+				'categories.id as category_id',
+				'categories.name as category_name',
+				'props.id as prop_id',
+				'props.text as prop_text',
+				'props.year',
+				'forecasts.forecast',
+				'resolutions.resolution',
+				sql<number>`power(resolutions.resolution::integer - forecasts.forecast, 2)`.as("score"),
+			])
+	).execute()
 }

--- a/forecast-app/types/db_types.ts
+++ b/forecast-app/types/db_types.ts
@@ -47,6 +47,7 @@ export interface PropsTable {
   text: string,
   category_id: number,
   year: number,
+  notes: string | null,
 }
 export type Prop = Selectable<PropsTable>
 export type NewProp = Insertable<PropsTable>
@@ -105,6 +106,7 @@ export type FeatureFlagUpdate = Updateable<FeatureFlagsTable>
 export interface VPropsView {
   prop_id: number,
   prop_text: string,
+  prop_notes: string | null,
   category_id: number,
   category_name: string,
   year: number,
@@ -119,6 +121,7 @@ export interface VForecastsView {
   category_name: string,
   prop_id: number,
   prop_text: string,
+  prop_notes: string | null,
   year: number,
   forecast: number,
   resolution: boolean | null,


### PR DESCRIPTION
Props now have "notes" that are shown when creating and editing props, and when making forecasts.

Additionally, hovering on a prop on a `PropsTable` will show its notes.

Closes #15 