### PR TITLE
Update many columns to be non-nullable

### DIFF
--- a/forecast-app/migrations/1732848043401_fix-nullable-columns.ts
+++ b/forecast-app/migrations/1732848043401_fix-nullable-columns.ts
@@ -1,0 +1,74 @@
+import type { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+	// Columns to switch from nullable to non-nullable
+	// users:
+	// - name, character varying
+	// - is_admin, boolean
+	// logins:
+	// - is_salted, boolean
+	// categories:
+	// - name, character varying
+	// forecasts:
+	// - prop_id, integer
+	// - user_id, integer
+	// - forecast, double precision
+	// props:
+	// - category_id, integer
+	// - text, character varying
+	// - year, integer
+	// resolutions:
+	// - prop_id, integer
+	// - resolution, boolean
+	await db.schema.alterTable('users')
+		.alterColumn('name', (ac) => ac.setNotNull())
+		.alterColumn('is_admin', (ac) => ac.setNotNull())
+		.execute()
+	await db.schema.alterTable('logins')
+		.alterColumn('is_salted', (ac) => ac.setNotNull())
+		.execute()
+	await db.schema.alterTable('categories')
+		.alterColumn('name', (ac) => ac.setNotNull())
+		.execute()
+	await db.schema.alterTable('forecasts')
+		.alterColumn('prop_id', (ac) => ac.setNotNull())
+		.alterColumn('user_id', (ac) => ac.setNotNull())
+		.alterColumn('forecast', (ac) => ac.setNotNull())
+		.execute()
+	await db.schema.alterTable('props')
+		.alterColumn('category_id', (ac) => ac.setNotNull())
+		.alterColumn('text', (ac) => ac.setNotNull())
+		.alterColumn('year', (ac) => ac.setNotNull())
+		.execute()
+	await db.schema.alterTable('resolutions')
+		.alterColumn('prop_id', (ac) => ac.setNotNull())
+		.alterColumn('resolution', (ac) => ac.setNotNull())
+		.execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await db.schema.alterTable('resolutions')
+		.alterColumn('prop_id', (ac) => ac.dropNotNull())
+		.alterColumn('resolution', (ac) => ac.dropNotNull())
+		.execute()
+	await db.schema.alterTable('props')
+		.alterColumn('category_id', (ac) => ac.dropNotNull())
+		.alterColumn('text', (ac) => ac.dropNotNull())
+		.alterColumn('year', (ac) => ac.dropNotNull())
+		.execute()
+	await db.schema.alterTable('forecasts')
+		.alterColumn('prop_id', (ac) => ac.dropNotNull())
+		.alterColumn('user_id', (ac) => ac.dropNotNull())
+		.alterColumn('forecast', (ac) => ac.dropNotNull())
+		.execute()
+	await db.schema.alterTable('categories')
+		.alterColumn('name', (ac) => ac.dropNotNull())
+		.execute()
+	await db.schema.alterTable('logins')
+		.alterColumn('is_salted', (ac) => ac.dropNotNull())
+		.execute()
+	await db.schema.alterTable('users')
+		.alterColumn('name', (ac) => ac.dropNotNull())
+		.alterColumn('is_admin', (ac) => ac.dropNotNull())
+		.execute()
+}

--- a/forecast-app/migrations/1732848043401_fix-nullable-columns.ts
+++ b/forecast-app/migrations/1732848043401_fix-nullable-columns.ts
@@ -1,25 +1,7 @@
 import type { Kysely } from 'kysely'
 
 export async function up(db: Kysely<any>): Promise<void> {
-	// Columns to switch from nullable to non-nullable
-	// users:
-	// - name, character varying
-	// - is_admin, boolean
-	// logins:
-	// - is_salted, boolean
-	// categories:
-	// - name, character varying
-	// forecasts:
-	// - prop_id, integer
-	// - user_id, integer
-	// - forecast, double precision
-	// props:
-	// - category_id, integer
-	// - text, character varying
-	// - year, integer
-	// resolutions:
-	// - prop_id, integer
-	// - resolution, boolean
+	// Fix columns that were nullable but shouldn't have been.
 	await db.schema.alterTable('users')
 		.alterColumn('name', (ac) => ac.setNotNull())
 		.alterColumn('is_admin', (ac) => ac.setNotNull())


### PR DESCRIPTION
There were quite a few columns that were nullable when I created the original schema. The migrations in this PR fix that.

Interesting, all the type definitions were already accurate as far as I can tell.

Closes #16