### PR TITLE
Allow editing forecasts

### DIFF
--- a/forecast-app/app/forecasts/[year]/user/[userId]/forecast-columns.tsx
+++ b/forecast-app/app/forecasts/[year]/user/[userId]/forecast-columns.tsx
@@ -35,7 +35,7 @@ export type ScoredForecast = {
 };
 
 export function useForecastColumns(
-  {editable, scored}: {editable: boolean, scored: boolean}
+  { editable, scored }: { editable: boolean; scored: boolean },
 ): ColumnDef<ScoredForecast>[] {
   const columns: ColumnDef<ScoredForecast>[] = [
     {
@@ -59,29 +59,6 @@ export function useForecastColumns(
       header: "Proposition",
     },
     {
-      accessorKey: "resolution",
-      header: "Res",
-      filterFn: (row, columnId, filterValue) => {
-        if (filterValue.length === 3 || filterValue.length === 0) return true;
-        switch (row.getValue("resolution")) {
-          case true:
-            return filterValue.includes("Yes");
-          case false:
-            return filterValue.includes("No");
-          case null:
-            return filterValue.includes("?");
-        }
-      },
-      cell: ({ row }) => {
-        const resolution = row.original.resolution;
-        return (
-          <div className="text-right">
-            {resolution === null ? "?" : resolution ? 1 : 0}
-          </div>
-        );
-      },
-    },
-    {
       accessorKey: "forecast",
       header: "Fcast",
       cell: ({ row }) => {
@@ -98,6 +75,31 @@ export function useForecastColumns(
     });
   }
   if (scored) {
+    columns.push(
+      {
+        accessorKey: "resolution",
+        header: "Res",
+        filterFn: (row, columnId, filterValue) => {
+          if (filterValue.length === 3 || filterValue.length === 0) return true;
+          switch (row.getValue("resolution")) {
+            case true:
+              return filterValue.includes("Yes");
+            case false:
+              return filterValue.includes("No");
+            case null:
+              return filterValue.includes("?");
+          }
+        },
+        cell: ({ row }) => {
+          const resolution = row.original.resolution;
+          return (
+            <div className="text-right">
+              {resolution === null ? "?" : resolution ? 1 : 0}
+            </div>
+          );
+        },
+      },
+    );
     columns.push(
       {
         accessorKey: "score",

--- a/forecast-app/app/forecasts/[year]/user/[userId]/forecast-columns.tsx
+++ b/forecast-app/app/forecasts/[year]/user/[userId]/forecast-columns.tsx
@@ -12,7 +12,6 @@ import {
 import {
   Dialog,
   DialogContent,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -36,7 +35,7 @@ export type ScoredForecast = {
 };
 
 export function useForecastColumns(
-  editable: boolean,
+  {editable, scored}: {editable: boolean, scored: boolean}
 ): ColumnDef<ScoredForecast>[] {
   const columns: ColumnDef<ScoredForecast>[] = [
     {
@@ -97,7 +96,8 @@ export function useForecastColumns(
       header: "Edit",
       cell: ({ row }) => <EditCell row={row} />,
     });
-  } else {
+  }
+  if (scored) {
     columns.push(
       {
         accessorKey: "score",

--- a/forecast-app/app/forecasts/[year]/user/[userId]/forecast-columns.tsx
+++ b/forecast-app/app/forecasts/[year]/user/[userId]/forecast-columns.tsx
@@ -2,7 +2,7 @@
 
 import { ColumnDef } from "@tanstack/react-table";
 import { Button } from "@/components/ui/button";
-import { ArrowUpDown } from "lucide-react";
+import { ArrowUpDown, Edit } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -18,95 +18,122 @@ export type ScoredForecast = {
   penalty: number | null;
 };
 
-export const forecastColumns: ColumnDef<ScoredForecast>[] = [
-  {
-    accessorKey: "category_name",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          size="sm"
-          className="px-1 py-0"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Category
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
+export function useForecastColumns(
+  editable: boolean,
+): ColumnDef<ScoredForecast>[] {
+  const columns: ColumnDef<ScoredForecast>[] = [
+    {
+      accessorKey: "category_name",
+      header: ({ column }) => {
+        return (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="px-1 py-0"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Category
+            <ArrowUpDown className="ml-2 h-4 w-4" />
+          </Button>
+        );
+      },
     },
-  },
-  {
-    accessorKey: "prop_text",
-    header: "Proposition",
-  },
-  {
-    accessorKey: "resolution",
-    header: "Res",
-    filterFn: (row, columnId, filterValue) => {
-      if (filterValue.length === 3 || filterValue.length === 0) return true;
-      switch (row.getValue("resolution")) {
-        case true:
-          return filterValue.includes("Yes");
-        case false:
-          return filterValue.includes("No");
-        case null:
-          return filterValue.includes("?");
-      }
+    {
+      accessorKey: "prop_text",
+      header: "Proposition",
     },
-    cell: ({ row }) => {
-      const resolution = row.original.resolution;
-      return (
-        <div className="text-right">
-          {resolution === null ? "?" : resolution ? 1 : 0}
-        </div>
-      );
+    {
+      accessorKey: "resolution",
+      header: "Res",
+      filterFn: (row, columnId, filterValue) => {
+        if (filterValue.length === 3 || filterValue.length === 0) return true;
+        switch (row.getValue("resolution")) {
+          case true:
+            return filterValue.includes("Yes");
+          case false:
+            return filterValue.includes("No");
+          case null:
+            return filterValue.includes("?");
+        }
+      },
+      cell: ({ row }) => {
+        const resolution = row.original.resolution;
+        return (
+          <div className="text-right">
+            {resolution === null ? "?" : resolution ? 1 : 0}
+          </div>
+        );
+      },
     },
-  },
-  {
-    accessorKey: "forecast",
-    header: "Fcast",
-    cell: ({ row }) => {
-      return <div className="text-right">{row.original.forecast}</div>;
+    {
+      accessorKey: "forecast",
+      header: "Fcast",
+      cell: ({ row }) => {
+        return (
+          <div className="text-right">{row.original.forecast}</div>
+        );
+      },
     },
-  },
-  {
-    accessorKey: "score",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          size="sm"
-          className="px-1 py-0"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Score
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
-      );
-    },
-    cell: ({ row }) => {
-      const penalty = row.original.penalty;
-      const expression = `(${
-        row.original.resolution ? 1 : 0
-      } - ${row.original.forecast})`;
-      const exprSpan = (
-        <span>
-          {expression}
-          <sup>2</sup>
-        </span>
-      );
-      return (
-        <div className="text-right px-2">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger>
-                {penalty && penalty.toFixed(2)}
-              </TooltipTrigger>
-              <TooltipContent>{penalty && exprSpan}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div>
-      );
-    },
-  },
-];
+  ];
+  // Editable tables have an edit button but no score column.
+  if (editable) {
+    columns.push({
+      accessorKey: "edit",
+      header: "Edit",
+      cell: ({ row }) => {
+        return (
+          <div className="text-right">
+            <Button size="icon" variant="ghost">
+              <Edit />
+            </Button>
+          </div>
+        );
+      },
+    });
+  } else {
+    columns.push(
+      {
+        accessorKey: "score",
+        header: ({ column }) => {
+          return (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="px-1 py-0"
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")}
+            >
+              Score
+              <ArrowUpDown className="ml-2 h-4 w-4" />
+            </Button>
+          );
+        },
+        cell: ({ row }) => {
+          const penalty = row.original.penalty;
+          const expression = `(${
+            row.original.resolution ? 1 : 0
+          } - ${row.original.forecast})`;
+          const exprSpan = (
+            <span>
+              {expression}
+              <sup>2</sup>
+            </span>
+          );
+          return (
+            <div className="text-right px-2">
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger>
+                    {penalty && penalty.toFixed(2)}
+                  </TooltipTrigger>
+                  <TooltipContent>{penalty && exprSpan}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+          );
+        },
+      },
+    );
+  }
+  return columns;
+}

--- a/forecast-app/app/forecasts/[year]/user/[userId]/forecast-columns.tsx
+++ b/forecast-app/app/forecasts/[year]/user/[userId]/forecast-columns.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ColumnDef } from "@tanstack/react-table";
+import { ColumnDef, Row } from "@tanstack/react-table";
 import { Button } from "@/components/ui/button";
 import { ArrowUpDown, Edit } from "lucide-react";
 import {
@@ -9,13 +9,30 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { RecordForecastForm } from "@/components/forms/record-forecast-form";
+import { Forecast, Prop, VProp } from "@/types/db_types";
+import { useState } from "react";
 
 export type ScoredForecast = {
+  category_id: number;
   category_name: string;
+  prop_id: number;
   prop_text: string;
+  prop_notes: string | null;
   resolution: boolean | null;
+  user_id: number;
   forecast: number;
+  forecast_id: number;
   penalty: number | null;
+  year: number;
 };
 
 export function useForecastColumns(
@@ -69,9 +86,7 @@ export function useForecastColumns(
       accessorKey: "forecast",
       header: "Fcast",
       cell: ({ row }) => {
-        return (
-          <div className="text-right">{row.original.forecast}</div>
-        );
+        return <div className="text-right">{row.original.forecast}</div>;
       },
     },
   ];
@@ -80,15 +95,7 @@ export function useForecastColumns(
     columns.push({
       accessorKey: "edit",
       header: "Edit",
-      cell: ({ row }) => {
-        return (
-          <div className="text-right">
-            <Button size="icon" variant="ghost">
-              <Edit />
-            </Button>
-          </div>
-        );
-      },
+      cell: ({ row }) => <EditCell row={row} />,
     });
   } else {
     columns.push(
@@ -136,4 +143,50 @@ export function useForecastColumns(
     );
   }
   return columns;
+}
+
+function EditCell({ row }: { row: Row<ScoredForecast> }) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const forecast: Forecast = {
+    id: row.original.forecast_id,
+    prop_id: row.original.prop_id,
+    user_id: row.original.user_id,
+    forecast: row.original.forecast,
+  };
+  const prop: VProp = {
+    prop_id: row.original.prop_id,
+    prop_text: row.original.prop_text,
+    prop_notes: row.original.prop_notes,
+    category_id: row.original.category_id,
+    category_name: row.original.category_name,
+    year: row.original.year,
+    resolution: row.original.resolution,
+  };
+  return (
+    <div className="text-right">
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogTrigger asChild>
+          <Button size="icon" variant="ghost">
+            <Edit />
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Forecast</DialogTitle>
+          </DialogHeader>
+          <RecordForecastForm prop={prop} initialForecast={forecast} />
+          <DialogFooter>
+            <Button
+              onClick={() => {
+                setDialogOpen(false);
+              }}
+            >
+              Cancel
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
 }

--- a/forecast-app/app/forecasts/[year]/user/[userId]/forecast-columns.tsx
+++ b/forecast-app/app/forecasts/[year]/user/[userId]/forecast-columns.tsx
@@ -18,7 +18,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { RecordForecastForm } from "@/components/forms/record-forecast-form";
-import { Forecast, Prop, VProp } from "@/types/db_types";
+import { Forecast, VProp } from "@/types/db_types";
 import { useState } from "react";
 
 export type ScoredForecast = {
@@ -176,15 +176,6 @@ function EditCell({ row }: { row: Row<ScoredForecast> }) {
             <DialogTitle>Edit Forecast</DialogTitle>
           </DialogHeader>
           <RecordForecastForm prop={prop} initialForecast={forecast} />
-          <DialogFooter>
-            <Button
-              onClick={() => {
-                setDialogOpen(false);
-              }}
-            >
-              Cancel
-            </Button>
-          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>

--- a/forecast-app/app/forecasts/[year]/user/[userId]/forecast-table.tsx
+++ b/forecast-app/app/forecasts/[year]/user/[userId]/forecast-table.tsx
@@ -27,12 +27,13 @@ import { ScoredForecast, useForecastColumns } from "./forecast-columns";
 interface DataTableProps {
   data: ScoredForecast[];
   editable: boolean;
+  scored: boolean;
 }
 
-export default function ForecastTable({ data, editable }: DataTableProps) {
+export default function ForecastTable({ data, editable, scored }: DataTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
-  const columns = useForecastColumns(editable);
+  const columns = useForecastColumns({editable, scored});
   const table = useReactTable({
     data,
     columns,

--- a/forecast-app/app/forecasts/[year]/user/[userId]/forecast-table.tsx
+++ b/forecast-app/app/forecasts/[year]/user/[userId]/forecast-table.tsx
@@ -30,10 +30,12 @@ interface DataTableProps {
   scored: boolean;
 }
 
-export default function ForecastTable({ data, editable, scored }: DataTableProps) {
+export default function ForecastTable(
+  { data, editable, scored }: DataTableProps,
+) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
-  const columns = useForecastColumns({editable, scored});
+  const columns = useForecastColumns({ editable, scored });
   const table = useReactTable({
     data,
     columns,
@@ -61,18 +63,22 @@ export default function ForecastTable({ data, editable, scored }: DataTableProps
             className="max-w-sm"
           />
         </div>
-        <div className="flex flex-col gap-3">
-          <Label>Filter by resolution:</Label>
-          <div className="flex flex-row w-full text-sm gap-6">
-            <ResolutionFilter
-              filterValue={table.getColumn("resolution")?.getFilterValue() as
-                | ResolutionOption[]
-                | undefined}
-              setFilterValue={(value) =>
-                table.getColumn("resolution")?.setFilterValue(value)}
-            />
-          </div>
-        </div>
+        {scored &&
+          (
+            <div className="flex flex-col gap-3">
+              <Label>Filter by resolution:</Label>
+              <div className="flex flex-row w-full text-sm gap-6">
+                <ResolutionFilter
+                  filterValue={table.getColumn("resolution")
+                    ?.getFilterValue() as
+                      | ResolutionOption[]
+                      | undefined}
+                  setFilterValue={(value) =>
+                    table.getColumn("resolution")?.setFilterValue(value)}
+                />
+              </div>
+            </div>
+          )}
       </div>
       <div className="rounded-md border w-full mt-8">
         <Table>

--- a/forecast-app/app/forecasts/[year]/user/[userId]/forecast-table.tsx
+++ b/forecast-app/app/forecasts/[year]/user/[userId]/forecast-table.tsx
@@ -22,18 +22,17 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
+import { ScoredForecast, useForecastColumns } from "./forecast-columns";
 
-interface DataTableProps<TData, TValue> {
-  columns: ColumnDef<TData, TValue>[];
-  data: TData[];
+interface DataTableProps {
+  data: ScoredForecast[];
+  editable: boolean;
 }
 
-export default function ForecastTable<TData, TValue>({
-  columns,
-  data,
-}: DataTableProps<TData, TValue>) {
+export default function ForecastTable({ data, editable }: DataTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const columns = useForecastColumns(editable);
   const table = useReactTable({
     data,
     columns,

--- a/forecast-app/app/forecasts/[year]/user/[userId]/page.tsx
+++ b/forecast-app/app/forecasts/[year]/user/[userId]/page.tsx
@@ -1,8 +1,12 @@
 import PageHeading from "@/components/page-heading";
-import { getForecasts, getPropYears, getUserById, getUsers } from "@/lib/db_actions";
+import {
+  getForecasts,
+  getPropYears,
+  getUserById,
+  getUsers,
+} from "@/lib/db_actions";
 import { notFound } from "next/navigation";
 import ForecastTable from "./forecast-table";
-import { forecastColumns } from "./forecast-columns";
 import { getUserFromCookies } from "@/lib/get-user";
 import { redirect } from "next/navigation";
 import UserYearSelector from "./user-year-selector";
@@ -19,22 +23,22 @@ export default async function Page(
   if (!requestedUser) {
     notFound();
   }
-  const allUsers = await getUsers({ sort: 'name asc' });
+  const allUsers = await getUsers({ sort: "name asc" });
   const years = await getPropYears();
   const forecasts = await getForecasts({ userId, year });
+  const thisYear = new Date().getFullYear();
   const scoredForecasts = forecasts.map((forecast) => {
     const resolution = forecast.resolution;
-    if (resolution === null) {
-      return {
-        ...forecast,
-        penalty: null,
-      };
+    const editable = forecast.user_id === authUser.id && year > thisYear;
+    let penalty = null;
+    if (resolution !== null) {
+      const resolutionAsNumber = resolution ? 1 : 0;
+      penalty = Math.pow(forecast.forecast - resolutionAsNumber, 2) || null;
     }
-    const resolutionAsNumber = resolution ? 1 : 0;
-    const penalty = Math.pow(forecast.forecast - resolutionAsNumber, 2) || null;
     return {
       ...forecast,
       penalty,
+      editable,
     };
   });
   return (
@@ -48,7 +52,7 @@ export default async function Page(
             selectedYear={year}
           />
         </PageHeading>
-        <ForecastTable data={scoredForecasts} columns={forecastColumns} />
+        <ForecastTable data={scoredForecasts} editable={year > thisYear} />
       </div>
     </main>
   );

--- a/forecast-app/app/forecasts/[year]/user/[userId]/page.tsx
+++ b/forecast-app/app/forecasts/[year]/user/[userId]/page.tsx
@@ -29,7 +29,6 @@ export default async function Page(
   const thisYear = new Date().getFullYear();
   const scoredForecasts = forecasts.map((forecast) => {
     const resolution = forecast.resolution;
-    const editable = forecast.user_id === authUser.id && year > thisYear;
     let penalty = null;
     if (resolution !== null) {
       const resolutionAsNumber = resolution ? 1 : 0;
@@ -38,9 +37,10 @@ export default async function Page(
     return {
       ...forecast,
       penalty,
-      editable,
     };
   });
+  const editable = year > thisYear && authUser.id === requestedUser.id;
+  const scored = year <= thisYear;
   return (
     <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
       <div className="w-full max-w-lg">
@@ -52,7 +52,11 @@ export default async function Page(
             selectedYear={year}
           />
         </PageHeading>
-        <ForecastTable data={scoredForecasts} editable={year > thisYear} />
+        <ForecastTable
+          data={scoredForecasts}
+          editable={editable}
+          scored={scored}
+        />
       </div>
     </main>
   );

--- a/forecast-app/app/forecasts/record/[year]/page.tsx
+++ b/forecast-app/app/forecasts/record/[year]/page.tsx
@@ -1,6 +1,6 @@
 import { getCategories, getForecasts, getProps } from "@/lib/db_actions";
 import { Category, VProp } from "@/types/db_types";
-import { RecordForecastForm } from "./record-forecast-form";
+import { RecordForecastForm } from "@/components/forms/record-forecast-form";
 import { getUserFromCookies, loginAndRedirect } from "@/lib/get-user";
 import PageHeading from "@/components/page-heading";
 import Link from "next/link";

--- a/forecast-app/components/forms/record-forecast-form.tsx
+++ b/forecast-app/components/forms/record-forecast-form.tsx
@@ -11,7 +11,7 @@ import {
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { NewForecast, VProp } from "@/types/db_types";
+import { Forecast, NewForecast, VProp } from "@/types/db_types";
 import { Button } from "@/components/ui/button";
 import { Check } from "lucide-react";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
@@ -24,10 +24,11 @@ const formSchema = z.object({
   ),
 });
 
-export function RecordForecastForm({ prop }: { prop: VProp }) {
+export function RecordForecastForm({ prop, initialForecast }: { prop: VProp, initialForecast?: Forecast }) {
   const { user } = useCurrentUser();
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
+    defaultValues: { forecast: initialForecast?.forecast ?? 0 },
   });
   const { toast } = useToast();
 

--- a/forecast-app/components/navbar/navbar.tsx
+++ b/forecast-app/components/navbar/navbar.tsx
@@ -32,7 +32,7 @@ export default async function NavBar() {
   const links: (Link | LinkGroup)[] = [{
     label: "Forecasts",
     links: [
-      { href: `/forecasts/2024/user/${userId}`, label: "2024 Forecasts" },
+      { href: `/forecasts/2024/user/${userId}`, label: "Previous Forecasts" },
     ],
   }, {
     label: "Scores",

--- a/forecast-app/lib/db_actions/forecasts.ts
+++ b/forecast-app/lib/db_actions/forecasts.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { NewForecast, VForecast } from '@/types/db_types';
+import { ForecastUpdate, NewForecast, VForecast } from '@/types/db_types';
 import { db } from '@/lib/database';
 import { getUserFromCookies } from '@/lib/get-user';
 import { revalidatePath } from 'next/cache';
@@ -23,6 +23,11 @@ export async function getForecasts(
 }
 
 export async function createForecast({ forecast }: { forecast: NewForecast }): Promise<number> {
+  // Make sure the user is who they say they.
+  const user = await getUserFromCookies();
+  if (!user || user.id !== forecast.user_id) {
+    throw new Error('Unauthorized');
+  }
   const { id } = await db
     .insertInto('forecasts')
     .values(forecast)
@@ -30,4 +35,34 @@ export async function createForecast({ forecast }: { forecast: NewForecast }): P
     .executeTakeFirstOrThrow();
   revalidatePath('/forecasts');
   return id;
+}
+
+export async function updateForecast({ id, forecast }: { id: number, forecast: ForecastUpdate }): Promise<void> {
+  // Make sure the user is who they say they.
+  const user = await getUserFromCookies();
+  if (!user || user.id !== forecast.user_id) {
+    console.log(`Attempted update by user '${user?.id}' on forecast ${id} for user ${forecast.user_id}`);
+    throw new Error('Unauthorized');
+  }
+  // Don't let users change any column except the forecast.
+  if (Object.keys(forecast).length !== 1 || !('forecast' in forecast)) {
+    console.log(`Attempted update with invalid columns: ${Object.keys(forecast)}`);
+    throw new Error('Unauthorized');
+  }
+  // Don't let users update forecasts for the current year.
+  const existingForecast = await db
+    .selectFrom('v_forecasts')
+    .where('forecast_id', '=', id)
+    .select('year')
+    .executeTakeFirstOrThrow();
+  const thisYear = new Date().getFullYear();
+  if (existingForecast.year <= thisYear) {
+    throw new Error('Cannot update forecasts for the current year');
+  }
+  await db
+    .updateTable('forecasts')
+    .set(forecast)
+    .where('id', '=', id)
+    .execute();
+  revalidatePath('/forecasts');
 }

--- a/forecast-app/migrations/1732982569359_add-id-columns-vforecasts.ts
+++ b/forecast-app/migrations/1732982569359_add-id-columns-vforecasts.ts
@@ -1,0 +1,53 @@
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+	// Add forecast_id and resolution_id columns to the v_forecasts view.
+	await db.schema.dropView('v_forecasts').execute();
+	await db.schema.createView('v_forecasts').as(
+		db.selectFrom('users')
+			.innerJoin('forecasts', 'users.id', 'forecasts.user_id')
+			.innerJoin('props', 'forecasts.prop_id', 'props.id')
+			.innerJoin('categories', 'props.category_id', 'categories.id')
+			.leftJoin('resolutions', 'props.id', 'resolutions.prop_id')
+			.select([
+				'users.id as user_id',
+				'users.name as user_name',
+				'categories.id as category_id',
+				'categories.name as category_name',
+				'props.id as prop_id',
+				'props.text as prop_text',
+				'props.notes as prop_notes',
+				'props.year',
+				'forecasts.id as forecast_id',
+				'forecasts.forecast',
+				'resolutions.id as resolution_id',
+				'resolutions.resolution',
+				sql<number>`power(resolutions.resolution::integer - forecasts.forecast, 2)`.as("score"),
+			])
+	).execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	// Restore the previous state of the view.
+	await db.schema.dropView('v_forecasts').execute();
+	await db.schema.createView('v_forecasts').as(
+		db.selectFrom('users')
+			.innerJoin('forecasts', 'users.id', 'forecasts.user_id')
+			.innerJoin('props', 'forecasts.prop_id', 'props.id')
+			.innerJoin('categories', 'props.category_id', 'categories.id')
+			.leftJoin('resolutions', 'props.id', 'resolutions.prop_id')
+			.select([
+				'users.id as user_id',
+				'users.name as user_name',
+				'categories.id as category_id',
+				'categories.name as category_name',
+				'props.id as prop_id',
+				'props.text as prop_text',
+				'props.notes as prop_notes',
+				'props.year',
+				'forecasts.forecast',
+				'resolutions.resolution',
+				sql<number>`power(resolutions.resolution::integer - forecasts.forecast, 2)`.as("score"),
+			])
+	).execute()
+}

--- a/forecast-app/types/db_types.ts
+++ b/forecast-app/types/db_types.ts
@@ -136,7 +136,9 @@ export interface VForecastsView {
   prop_text: string,
   prop_notes: string | null,
   year: number,
+  forecast_id: number
   forecast: number,
+  resolution_id: number | null,
   resolution: boolean | null,
   score: number | null,
 }


### PR DESCRIPTION
This PR closes #24 by updating the `/forecasts/[year]/user/[user]` page to have an edit button when the year is in the future and the user is viewing their own forecasts.

<img width="606" alt="image" src="https://github.com/user-attachments/assets/2de0f21c-93e0-46af-98e7-d5e38bca3c78">
