### PR TITLE
Remove feature flag for 2025-forecasts

### DIFF
--- a/forecast-app/app/page.tsx
+++ b/forecast-app/app/page.tsx
@@ -18,11 +18,6 @@ export default async function Home() {
     userId: user.id,
     year: 2025,
   });
-  const canSee2025Forecasts = await hasFeatureEnabled({
-    featureName: "2025-forecasts",
-    userId: user.id,
-  });
-  console.log(unforecastedProps);
   return (
     <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
       <div className="w-full max-w-lg">
@@ -38,7 +33,7 @@ export default async function Home() {
             <Link href="/scores/2024">2024 Scores</Link>
           </li>
         </ul>
-        {canSee2025Forecasts && unforecastedProps.length > 0 && (
+        {unforecastedProps.length > 0 && (
           <div className="mt-5 text-lg">
             <p className="font-semibold">
               You have 2025 forecasts to do!

--- a/forecast-app/components/navbar/navbar.tsx
+++ b/forecast-app/components/navbar/navbar.tsx
@@ -41,9 +41,7 @@ export default async function NavBar() {
       label: "2024 Scores",
     }],
   }];
-  if (
-    userId && await hasFeatureEnabled({ featureName: "2025-forecasts", userId })
-  ) {
+  if (userId) {
     const forecastLinks = links.find(({ label }) =>
       label === "Forecasts"
     ) as LinkGroup;

--- a/forecast-app/migrations/1732991808870_remove-flag-2025-fcasts.ts
+++ b/forecast-app/migrations/1732991808870_remove-flag-2025-fcasts.ts
@@ -1,0 +1,16 @@
+import type { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+	// Remove the feature flag for 2025-forecasts now that it's been fully released.
+	await db
+		.deleteFrom('feature_flags')
+		.where('name', '=', '2025-forecasts')
+		.execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await db
+		.insertInto('feature_flags')
+		.values({ name: '2025-forecasts', user_id: null, enabled: true })
+		.execute()
+}


### PR DESCRIPTION
2025 forecasts are now generally available so the flag isn't necessary. This removes it from the code and the db.