### PR TITLE
Implement invite links

### DIFF
--- a/forecast-app/app/admin/users/invite-user-button.tsx
+++ b/forecast-app/app/admin/users/invite-user-button.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { generateInviteToken } from "@/lib/db_actions/invite-tokens";
+import { useState } from "react";
+import { LoaderCircle } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+
+export function InviteUserButton({ className }: { className?: string }) {
+  const [inviteCode, setInviteCode] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const { toast } = useToast();
+  async function generateInviteCode() {
+    setLoading(true);
+    const inviteToken = await generateInviteToken();
+    setInviteCode(inviteToken);
+    setLoading(false);
+  }
+  async function copyInviteLink() {
+    if (!inviteCode) return;
+    const host = window.location.host;
+    const protocol = window.location.protocol;
+    const url = `${protocol}//${host}/register?token=${inviteCode}`;
+    await navigator.clipboard.writeText(url);
+    toast({
+      title: "Link copied!",
+      description: "The invite link has been copied to your clipboard.",
+    })
+  }
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button className={className}>Create Invite Link</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Invite User</DialogTitle>
+        </DialogHeader>
+        {loading
+          ? (
+            <div className="w-full flex justify-center">
+              <LoaderCircle className="animate-spin" />
+            </div>
+          )
+          : (
+            <Button disabled={inviteCode !== null} onClick={generateInviteCode}>
+              Generate Invite Code
+            </Button>
+          )}
+        <Input value={inviteCode ?? undefined} readOnly />
+        {inviteCode && (
+          <Button onClick={copyInviteLink}>
+            Copy Link to Clipboard
+          </Button>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/forecast-app/app/admin/users/page.tsx
+++ b/forecast-app/app/admin/users/page.tsx
@@ -2,6 +2,7 @@ import { DataTable } from "./data-table";
 import PageHeading from "@/components/page-heading";
 import { getUsers } from "@/lib/db_actions";
 import { getUserFromCookies } from "@/lib/get-user";
+import { InviteUserButton } from "./invite-user-button";
 
 export default async function Page() {
   const user = await getUserFromCookies();
@@ -10,7 +11,9 @@ export default async function Page() {
   return (
     <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
       <div className="w-full max-w-lg">
-        <PageHeading title="Users" />
+        <PageHeading title="Users">
+          <InviteUserButton className="ml-8" />
+        </PageHeading>
         {authorized
           ? <DataTable data={users} />
           : <p>Unauthorized: only admins can see users</p>}

--- a/forecast-app/app/register/page.tsx
+++ b/forecast-app/app/register/page.tsx
@@ -1,9 +1,12 @@
 import RegisterFormCard from "./register-form-card";
 
-export default function RegisterPage() {
+export default async function RegisterPage(
+  { searchParams }: { searchParams: Promise<{ token?: string }> },
+) {
+  const { token } = await searchParams;
   return (
     <div className="flex items-center justify-center pt-4">
-      <RegisterFormCard />
+      <RegisterFormCard inviteToken={token} />
     </div>
   );
 }

--- a/forecast-app/app/register/register-form-card.tsx
+++ b/forecast-app/app/register/register-form-card.tsx
@@ -34,10 +34,9 @@ const formSchema = z.object({
     "Must contain only letters, hyphens, and spaces",
   ).min(2).max(30),
   email: z.string().email(),
-  registrationSecret: z.string().min(5).max(8),
 });
 
-export default function RegisterFormCard() {
+export default function RegisterFormCard({inviteToken}: {inviteToken?: string}) {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const router = useRouter();
@@ -47,14 +46,14 @@ export default function RegisterFormCard() {
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setLoading(true);
-    registerNewUser(values).catch((error) => {
+    registerNewUser({...values, inviteToken}).then(() => {
+      router.push("/login");
+    }).catch((error) => {
       if (error instanceof Error) {
         setError(error.message);
       } else {
         setError("An error occurred.");
       }
-    }).then(() => {
-      router.push("/login");
     }).finally(() => {
       setLoading(false);
     });
@@ -134,26 +133,6 @@ export default function RegisterFormCard() {
                       {...field}
                     />
                   </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="registrationSecret"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Registration Secret</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="password"
-                      placeholder="something-very-secret"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Get this from Ethan
-                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/forecast-app/components/page-heading.tsx
+++ b/forecast-app/components/page-heading.tsx
@@ -1,7 +1,7 @@
 export default function PageHeading({ title, className, children }: { title: string, className?: string, children?: React.ReactNode }) {
   return (
     <header className={`mb-4 ${className}`}>
-      <h1 className="text-2xl font-bold">{title}</h1>
+      <h1 className="text-2xl font-bold inline">{title}</h1>
       {children}
     </header>
   );

--- a/forecast-app/lib/auth/register.ts
+++ b/forecast-app/lib/auth/register.ts
@@ -3,42 +3,61 @@
 import argon2 from 'argon2';
 import { createLogin, createUser, getLoginByUsername } from '@/lib/db_actions';
 import * as dotenv from 'dotenv';
+import { getUserFromCookies } from '../get-user';
+import { consumeInviteToken, inviteTokenIsValid } from '../db_actions/invite-tokens';
+import { request } from 'http';
 dotenv.config({ path: '.env.local' });
 
-const REGISTRATION_SECRET = process.env.REGISTRATION_SECRET;
 const SALT = process.env.ARGON2_SALT;
 
 /// Create a new user.
 export async function registerNewUser(
-  { username, password, name, email, registrationSecret }:
-    { username: string, password: string, name: string, email: string, registrationSecret: string }
+  { username, password, name, email, inviteToken }:
+    { username: string, password: string, name: string, email: string, inviteToken?: string }
 ) {
-  // The "registrationSecret" is a secret key that is required to register a new user.
-  if (registrationSecret !== REGISTRATION_SECRET) {
-    throw new Error('Incorrect registration_secret.');
+  const requestingUser = await getUserFromCookies();
+  // The user must be an admin OR provide a valid invite token.
+  if (requestingUser?.is_admin) {
+    console.log('User is an admin.');
+  } else {
+    if (!inviteToken) {
+      throw new Error('No invite token provided.');
+    }
+    // Check if the invite token is valid
+    const tokenIsValid = await inviteTokenIsValid(inviteToken);
+    if (!tokenIsValid) {
+      throw new Error('Invalid invite token.');
+    }
+    console.log('Confirmed valid invite token.');
   }
 
   if (!username || !password) {
     throw new Error('Username and password are required.');
   }
 
-  // Check if the username already exists
+  // Check if the username already exists.
   const existingLogin = await getLoginByUsername(username);
-
   if (existingLogin) {
     throw new Error('Username already exists.');
   }
 
-  // Make sure the password is valid: at least 8 characters
+  // Make sure the password is valid: at least 8 characters.
   if (password.length < 8) {
     throw new Error('Password must be at least 8 characters long.');
   }
 
-  // Create the login
+  // Create the login.
   const passwordHash = await argon2.hash(SALT + password, { type: argon2.argon2id });
   const login = { username, password_hash: passwordHash, is_salted: true };
   const loginId = await createLogin({ login });
 
+  // Create the user.
   const user = { name, email, login_id: loginId, is_admin: false }
   await createUser({ user });
+  console.log(`User ${username} created.`);
+
+  // Consume the invite token, if one was provided.
+  if (inviteToken) {
+    await consumeInviteToken(inviteToken);
+  }
 }

--- a/forecast-app/lib/db_actions/invite-tokens.ts
+++ b/forecast-app/lib/db_actions/invite-tokens.ts
@@ -1,0 +1,50 @@
+"use server";
+
+import { getUserFromCookies } from "../get-user";
+import { randomBytes } from "crypto";
+import { db } from '@/lib/database';
+
+
+export async function generateInviteToken() {
+  const user = await getUserFromCookies();
+  if (!user?.is_admin) {
+    throw new Error('Unauthorized');
+  }
+  // Create the token.
+  const token = randomBytes(16).toString("hex");
+  // Save it to the db.
+  await db
+    .insertInto('invite_tokens')
+    .values({ token, created_at: new Date })
+    .execute();
+  return token;
+}
+
+export async function inviteTokenIsValid(token: string) {
+  const invite = await db
+    .selectFrom('invite_tokens')
+    .selectAll()
+    .where('token', '=', token)
+    .executeTakeFirst();
+  if (invite === undefined) {
+    console.log('Invite token does not exist.');
+    return false;
+  };
+  if (invite.used_at !== null) {
+    console.log('Invite token has already been used.');
+    return false;
+  }
+  return true;
+}
+
+export async function consumeInviteToken(token: string) {
+  const invite = await db
+    .updateTable('invite_tokens')
+    .where('token', '=', token)
+    .set({ used_at: new Date })
+    .returning('token')
+    .execute();
+  if (!invite) {
+    throw new Error('Invalid invite token.');
+  }
+}

--- a/forecast-app/lib/db_actions/password-reset-tokens.ts
+++ b/forecast-app/lib/db_actions/password-reset-tokens.ts
@@ -2,10 +2,9 @@
 
 import { randomBytes } from "crypto";
 import { db } from '@/lib/database';
-import { getLoginByUsername } from "./logins";
 import { headers } from 'next/headers'
 import { sendEmail } from "../email";
-import { updateLoginPassword, updateLoginPasswordFromResetToken } from "../auth";
+import { updateLoginPasswordFromResetToken } from "../auth";
 
 const PASSWORD_RESET_TOKEN_LIFESPAN_MINUTES = 15;
 

--- a/forecast-app/migrations/1732993480596_create-table-invite-secrets.ts
+++ b/forecast-app/migrations/1732993480596_create-table-invite-secrets.ts
@@ -2,15 +2,15 @@ import type { Kysely } from 'kysely'
 
 export async function up(db: Kysely<any>): Promise<void> {
 	await db.schema
-		.createTable('invite_secrets')
+		.createTable('invite_tokens')
 		.addColumn('id', 'serial', (col) => col.primaryKey())
-		.addColumn('secret', 'text', (col) => col.notNull())
+		.addColumn('token', 'text', (col) => col.notNull())
 		.addColumn('created_at', 'timestamptz', (col) => col.notNull())
 		.addColumn('used_at', 'timestamptz')
-		.addUniqueConstraint('secret_unique', ['secret'], (builder) => builder.nullsNotDistinct())
+		.addUniqueConstraint('token_unique', ['token'], (builder) => builder.nullsNotDistinct())
 		.execute()
 }
 
 export async function down(db: Kysely<any>): Promise<void> {
-	await db.schema.dropTable('invite_secrets').execute()
+	await db.schema.dropTable('invite_tokens').execute()
 }

--- a/forecast-app/migrations/1732993480596_create-table-invite-secrets.ts
+++ b/forecast-app/migrations/1732993480596_create-table-invite-secrets.ts
@@ -1,0 +1,16 @@
+import type { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+	await db.schema
+		.createTable('invite_secrets')
+		.addColumn('id', 'serial', (col) => col.primaryKey())
+		.addColumn('secret', 'text', (col) => col.notNull())
+		.addColumn('created_at', 'timestamptz', (col) => col.notNull())
+		.addColumn('used_at', 'timestamptz')
+		.addUniqueConstraint('secret_unique', ['secret'], (builder) => builder.nullsNotDistinct())
+		.execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await db.schema.dropTable('invite_secrets').execute()
+}

--- a/forecast-app/types/db_types.ts
+++ b/forecast-app/types/db_types.ts
@@ -6,15 +6,16 @@ import {
 } from 'kysely';
 
 export interface Database {
-  users: UsersTable,
   categories: CategoriesTable,
-  props: PropsTable,
-  forecasts: ForecastsTable,
-  resolutions: ResolutionsTable,
-  logins: LoginsTable,
-  suggested_props: SuggestedPropsTable,
   feature_flags: FeatureFlagsTable,
+  forecasts: ForecastsTable,
+  invite_tokens: InviteTokensTable,
+  logins: LoginsTable,
   password_reset_tokens: PasswordResetTokensTable,
+  props: PropsTable,
+  resolutions: ResolutionsTable,
+  suggested_props: SuggestedPropsTable,
+  users: UsersTable,
   v_props: VPropsView,
   v_forecasts: VForecastsView,
   v_users: VUsersView,
@@ -113,6 +114,16 @@ export interface PasswordResetTokensTable {
 export type PasswordReset = Selectable<PasswordResetTokensTable>
 export type NewPasswordReset = Insertable<PasswordResetTokensTable>
 export type PasswordResetUpdate = Updateable<PasswordResetTokensTable>
+
+export interface InviteTokensTable {
+  id: Generated<number>,
+  token: string,
+  created_at: Date,
+  used_at: Date | null,
+}
+export type InviteToken = Selectable<InviteTokensTable>;
+export type NewInviteToken = Insertable<InviteTokensTable>;
+export type InviteTokenUpdate = Updateable<InviteTokensTable>;
 
 // Views
 


### PR DESCRIPTION
From now on, users create new accounts via invite links.

Admins can create invite tokens, which are stored in the `invite_tokens` table. Then they can copy the full link (`/register?token=abc123`) to their clipboard and proceed to send it to invitees.

When a registrant signs up for an account, their invite token is checked against the `invite_tokens` table (including whether it's already been used). If it's valid, the user and login entries are created, and then the token is marked as used. However, admins are an exception: when logged in, they can create new accounts without any invite token.

Closes #23.