### PR TITLE
Remove is_salted column

### DIFF
--- a/forecast-app/app/admin/users/columns.tsx
+++ b/forecast-app/app/admin/users/columns.tsx
@@ -28,6 +28,11 @@ export function getColumns(
       header: "User ID",
     },
     {
+      accessorKey: "is_admin",
+      header: "Admin",
+      cell: ({ row }) => row.original.is_admin && "Y",
+    },
+    {
       accessorKey: "username",
       header: "Username",
       cell: ({ row }) => {
@@ -65,16 +70,6 @@ export function getColumns(
     {
       accessorKey: "name",
       header: "Name",
-    },
-    {
-      accessorKey: "is_admin",
-      header: "Admin",
-      cell: ({ row }) => row.original.is_admin && "Y",
-    },
-    {
-      accessorKey: "is_salted",
-      header: "Salted",
-      cell: ({ row }) => row.original.is_salted && "Y",
     },
     {
       accessorKey: "email",

--- a/forecast-app/app/admin/users/columns.tsx
+++ b/forecast-app/app/admin/users/columns.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dialog";
 import { loginViaImpersonation } from "@/lib/auth";
 import { redirect } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
 
 export function getColumns(
   { mutateUser }: { mutateUser: () => void },
@@ -21,16 +22,11 @@ export function getColumns(
   return [
     {
       accessorKey: "login_id",
-      header: "Login ID",
+      header: "Login",
     },
     {
       accessorKey: "id",
-      header: "User ID",
-    },
-    {
-      accessorKey: "is_admin",
-      header: "Admin",
-      cell: ({ row }) => row.original.is_admin && "Y",
+      header: "User",
     },
     {
       accessorKey: "username",
@@ -48,7 +44,14 @@ export function getColumns(
         return (
           <Dialog>
             <DialogTrigger asChild>
-              <Button variant="ghost">{username}</Button>
+              <Button variant="ghost" className="flex-col gap-y-1 h-auto">
+                {username}
+                {row.original.is_admin && (
+                  <Badge variant="outline">
+                    Admin
+                  </Badge>
+                )}
+              </Button>
             </DialogTrigger>
             <DialogContent>
               <DialogHeader>

--- a/forecast-app/app/admin/users/page.tsx
+++ b/forecast-app/app/admin/users/page.tsx
@@ -8,6 +8,7 @@ export default async function Page() {
   const user = await getUserFromCookies();
   const authorized = user?.is_admin;
   const users = authorized ? await getUsers() : [];
+  users.sort((a, b) => a.id - b.id);
   return (
     <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
       <div className="w-full max-w-lg">

--- a/forecast-app/components/ui/badge.tsx
+++ b/forecast-app/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/forecast-app/lib/auth/login.ts
+++ b/forecast-app/lib/auth/login.ts
@@ -14,30 +14,14 @@ const SALT = process.env.ARGON2_SALT;
 export async function login({ username, password }: { username: string, password: string }) {
   // Fetch the user from the database
   const login = await getLoginByUsername(username);
-
   if (!login) {
     throw new Error('Invalid username or password.');
   }
 
   // Verify the password
-  // Legacy users didn't have salted passwords, so we check before salting.
-  const passwordToVerify = login.is_salted ? SALT + password : password;
-  const isValid = await argon2.verify(login.password_hash, passwordToVerify);
-
+  const isValid = await argon2.verify(login.password_hash, SALT + password);
   if (!isValid) {
     throw new Error('Invalid username or password.');
-  }
-
-  ////////////////////////////////////////
-  // Temporary patch: fix unsalted users
-  ////////////////////////////////////////
-  if (!login.is_salted) {
-    const newPasswordHash = await argon2.hash(SALT + password, { type: argon2.argon2id });
-    await db
-      .updateTable('logins')
-      .set({ 'password_hash': newPasswordHash, is_salted: true })
-      .where('id', '=', login.id)
-      .execute();
   }
 
   // Create a JWT token
@@ -45,7 +29,6 @@ export async function login({ username, password }: { username: string, password
     throw new Error('JWT_SECRET is not set.');
   }
   const token = jwt.sign({ loginId: login.id }, JWT_SECRET, { expiresIn: '3h' });
-
   // Set the token in an HTTP-only cookie
   const cookieStore = await cookies();
   cookieStore.set('token', token, {

--- a/forecast-app/lib/auth/register.ts
+++ b/forecast-app/lib/auth/register.ts
@@ -5,7 +5,6 @@ import { createLogin, createUser, getLoginByUsername } from '@/lib/db_actions';
 import * as dotenv from 'dotenv';
 import { getUserFromCookies } from '../get-user';
 import { consumeInviteToken, inviteTokenIsValid } from '../db_actions/invite-tokens';
-import { request } from 'http';
 dotenv.config({ path: '.env.local' });
 
 const SALT = process.env.ARGON2_SALT;
@@ -48,7 +47,7 @@ export async function registerNewUser(
 
   // Create the login.
   const passwordHash = await argon2.hash(SALT + password, { type: argon2.argon2id });
-  const login = { username, password_hash: passwordHash, is_salted: true };
+  const login = { username, password_hash: passwordHash };
   const loginId = await createLogin({ login });
 
   // Create the user.

--- a/forecast-app/lib/auth/update-password.ts
+++ b/forecast-app/lib/auth/update-password.ts
@@ -19,7 +19,7 @@ export async function updateLoginPassword({ id, currentPassword, newPassword }: 
   const newHash = await argon2.hash(SALT + newPassword, { type: argon2.argon2id });
   await db
     .updateTable('logins')
-    .set({ password_hash: newHash, is_salted: true })
+    .set({ password_hash: newHash })
     .where('id', '=', id)
     .execute();
 }
@@ -46,7 +46,7 @@ export async function updateLoginPasswordFromResetToken({ username, token, passw
   const newHash = await argon2.hash(SALT + password, { type: argon2.argon2id });
   await db
     .updateTable('logins')
-    .set({ password_hash: newHash, is_salted: true })
+    .set({ password_hash: newHash })
     .where('id', '=', user.login_id)
     .execute();
   // Delete the now-used token.

--- a/forecast-app/migrations/1733071132579_alter-logins-table-remove-salt-col.ts
+++ b/forecast-app/migrations/1733071132579_alter-logins-table-remove-salt-col.ts
@@ -1,0 +1,59 @@
+import type { Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+	// Remove v_users and the views that depend on it.
+	await db.schema.dropView('v_password_reset_tokens').execute()
+	await db.schema.dropView('v_suggested_props').execute()
+	await db.schema.dropView('v_users').execute()
+
+	// Remove the is_salted column from the underlying logins table.
+	await db.schema
+		.alterTable('logins')
+		.dropColumn('is_salted')
+		.execute()
+
+	// Recreate v_users without the is_salted column.
+	await db.schema.createView('v_users').as(
+		db.selectFrom('users')
+			.leftJoin('logins', 'users.login_id', 'logins.id')
+			.select(['users.id', 'users.name', 'users.email', 'users.is_admin',
+				'logins.id as login_id', 'logins.username'])
+	).execute()
+	// Recreate v_suggested_props and v_password_resets.
+	await db.schema.createView('v_suggested_props').as(
+		db.selectFrom('suggested_props')
+			.innerJoin('v_users', 'suggested_props.suggester_user_id', 'v_users.id')
+			.select([
+				'suggested_props.id', 'prop as prop_text', 'suggester_user_id as user_id', 'login_id as user_login_id',
+				'name as user_name', 'email as user_email', 'username as user_username',
+			])
+	).execute()
+	await db.schema
+		.createView('v_password_reset_tokens').as(
+			db.selectFrom('password_reset_tokens')
+				.innerJoin('v_users', 'password_reset_tokens.login_id', 'v_users.login_id')
+				.select([
+					'password_reset_tokens.id', 'password_reset_tokens.login_id', 'password_reset_tokens.token',
+					'password_reset_tokens.initiated_at', 'password_reset_tokens.expires_at',
+					'v_users.username', 'v_users.id as user_id', 'v_users.name', 'v_users.email'
+				])
+		)
+		.execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	// Down migration is simpler: just re-add the column and update the v_users view.
+	await db.schema
+		.alterTable('logins')
+		.addColumn('is_salted', 'boolean', (c) => c.defaultTo(false))
+		.execute()
+	await db.updateTable('logins').set({ is_salted: true }).execute()
+	// Update the v_users view to include the salt column.
+	// By using "orReplace", we can avoid dropping the view (and updating dependents) and recreating it.
+	await db.schema.createView('v_users').orReplace().as(
+		db.selectFrom('users')
+			.leftJoin('logins', 'users.login_id', 'logins.id')
+			.select(['users.id', 'users.name', 'users.email', 'users.is_admin',
+				'logins.id as login_id', 'logins.username', 'logins.is_salted'])
+	).execute()
+}

--- a/forecast-app/types/db_types.ts
+++ b/forecast-app/types/db_types.ts
@@ -79,7 +79,6 @@ export interface LoginsTable {
   id: Generated<number>,
   username: string,
   password_hash: string,
-  is_salted: boolean,
 }
 export type Login = Selectable<LoginsTable>
 export type NewLogin = Insertable<LoginsTable>
@@ -162,7 +161,6 @@ export interface VUsersView {
   is_admin: boolean,
   login_id: number | null,
   username: string | null,
-  is_salted: boolean | null,
 }
 export type VUser = Selectable<VUsersView>
 


### PR DESCRIPTION
Now that all users' password hashes are salted, I removed the `is_salted` column from the database and anywhere else it was being used. Mostly this just simplifies the code.

I also cleaned up the `/admin/users` page a bit while I was at it.