### PR TITLE
Allow user-scoped props

### DIFF
--- a/app/props/[year]/page.tsx
+++ b/app/props/[year]/page.tsx
@@ -16,11 +16,8 @@ export default async function Page(
   const allowEdits = user?.is_admin || false;
   const years = await getPropYears();
   years.sort((a, b) => b - a);
-  const propsAndResolutions = await getProps({
-    year,
-    personal: false,
-    common: true,
-  });
+  // Passing null as the userId gets us only public props.
+  const propsAndResolutions = await getProps({ year, userId: null });
   return (
     <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
       <div className="w-full max-w-3xl">

--- a/app/props/[year]/user/[userId]/page.tsx
+++ b/app/props/[year]/user/[userId]/page.tsx
@@ -5,15 +5,21 @@ import YearSelector from "../../year-selector";
 import { getUserFromCookies } from "@/lib/get-user";
 
 export default async function Page(
-  { params }: { params: Promise<{ year: number; userId: number }> },
+  { params }: { params: Promise<{ year: string; userId: string }> },
 ) {
-  const { year, userId } = await params;
-  // Check that year is a number.
+  const year = parseInt((await params).year, 10);
+  const userId = parseInt((await params).userId, 10);
+  // Check that year & user were numbers
   if (isNaN(year)) {
     throw new Error("Invalid year");
   }
+  if (isNaN(userId)) {
+    throw new Error("Invalid user ID");
+  }
   const user = await getUserFromCookies();
-  const allowEdits = user?.is_admin || false;
+  if (user?.id !== userId) {
+    throw new Error("You don't have permission to view this page");
+  }
   const years = await getPropYears();
   years.sort((a, b) => b - a);
   const propsAndResolutions = await getProps({
@@ -35,7 +41,7 @@ export default async function Page(
         </PageHeading>
         <PropTable
           data={propsAndResolutions}
-          editable={allowEdits}
+          editable={true}
           defaultPropUserId={userId}
         />
       </div>

--- a/app/props/[year]/user/[userId]/page.tsx
+++ b/app/props/[year]/user/[userId]/page.tsx
@@ -3,6 +3,7 @@ import PropTable from "@/components/tables/prop-table";
 import PageHeading from "@/components/page-heading";
 import YearSelector from "../../year-selector";
 import { getUserFromCookies } from "@/lib/get-user";
+import ErrorPage from "@/components/pages/error-page";
 
 export default async function Page(
   { params }: { params: Promise<{ year: string; userId: string }> },
@@ -17,8 +18,18 @@ export default async function Page(
     throw new Error("Invalid user ID");
   }
   const user = await getUserFromCookies();
-  if (user?.id !== userId) {
-    throw new Error("You don't have permission to view this page");
+  if (user?.id !== userId && user?.is_admin === false) {
+    return (
+      <ErrorPage title="Unauthorized">
+        <p>You don't have permission to view props for other users.</p>
+        <p className="text-muted-foreground">
+          Your user ID is{" "}
+          <code className="bg-muted">{user?.id}</code>, but you're attempting to
+          view props for user ID{" "}
+          <code>{userId}</code>.<br />Please log in with the correct account.
+        </p>
+      </ErrorPage>
+    );
   }
   const years = await getPropYears();
   years.sort((a, b) => b - a);

--- a/app/props/[year]/user/[userId]/page.tsx
+++ b/app/props/[year]/user/[userId]/page.tsx
@@ -22,11 +22,7 @@ export default async function Page(
   }
   const years = await getPropYears();
   years.sort((a, b) => b - a);
-  const propsAndResolutions = await getProps({
-    year,
-    personal: true,
-    common: false,
-  });
+  const propsAndResolutions = await getProps({ year, userId: userId });
   return (
     <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
       <div className="w-full max-w-3xl">

--- a/app/props/[year]/user/[userId]/page.tsx
+++ b/app/props/[year]/user/[userId]/page.tsx
@@ -33,7 +33,11 @@ export default async function Page(
             selectedYear={year}
           />
         </PageHeading>
-        <PropTable data={propsAndResolutions} editable={allowEdits} />
+        <PropTable
+          data={propsAndResolutions}
+          editable={allowEdits}
+          defaultPropUserId={userId}
+        />
       </div>
     </main>
   );

--- a/app/props/[year]/user/[userId]/page.tsx
+++ b/app/props/[year]/user/[userId]/page.tsx
@@ -1,13 +1,13 @@
 import { getProps, getPropYears } from "@/lib/db_actions";
 import PropTable from "@/components/tables/prop-table";
 import PageHeading from "@/components/page-heading";
-import YearSelector from "./year-selector";
+import YearSelector from "../../year-selector";
 import { getUserFromCookies } from "@/lib/get-user";
 
 export default async function Page(
-  { params }: { params: Promise<{ year: number }> },
+  { params }: { params: Promise<{ year: number; userId: number }> },
 ) {
-  const { year } = await params;
+  const { year, userId } = await params;
   // Check that year is a number.
   if (isNaN(year)) {
     throw new Error("Invalid year");
@@ -18,14 +18,14 @@ export default async function Page(
   years.sort((a, b) => b - a);
   const propsAndResolutions = await getProps({
     year,
-    personal: false,
-    common: true,
+    personal: true,
+    common: false,
   });
   return (
     <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
       <div className="w-full max-w-3xl">
         <PageHeading
-          title="Public Props"
+          title="Personal Props"
           className="flex flex-row flex-wrap gap-x-4 lg:gap-x-8 items-end mb-4 sm:mb-8"
         >
           <YearSelector

--- a/app/props/[year]/user/[userId]/page.tsx
+++ b/app/props/[year]/user/[userId]/page.tsx
@@ -21,10 +21,10 @@ export default async function Page(
   if (user?.id !== userId && user?.is_admin === false) {
     return (
       <ErrorPage title="Unauthorized">
-        <p>You don't have permission to view props for other users.</p>
+        <p>You don&apos;t have permission to view props for other users.</p>
         <p className="text-muted-foreground">
           Your user ID is{" "}
-          <code className="bg-muted">{user?.id}</code>, but you're attempting to
+          <code className="bg-muted">{user?.id}</code>, but you&apos;re attempting to
           view props for user ID{" "}
           <code>{userId}</code>.<br />Please log in with the correct account.
         </p>

--- a/components/forms/create-edit-prop-form.tsx
+++ b/components/forms/create-edit-prop-form.tsx
@@ -31,6 +31,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { getUserFromCookies } from "@/lib/get-user";
 
 const formSchema = z.object({
   text: z.string().min(8).max(1000),
@@ -62,6 +63,7 @@ export function CreateEditPropForm(
   const [loading, setLoading] = useState(true);
   const [categories, setCategories] = useState<Category[]>([]);
   const [years, setYears] = useState<number[]>([]);
+  const [canEditPublicProps, setCanEditPublicProps] = useState(false);
   const { toast } = useToast();
   const initialUserId = initialProp?.prop_user_id || defaultUserId;
   const form = useForm<z.infer<typeof formSchema>>({
@@ -80,6 +82,11 @@ export function CreateEditPropForm(
       const years = await getPropYears();
       setYears(years);
       setLoading(false);
+    });
+    getUserFromCookies().then((user) => {
+      if (user && user.is_admin) {
+        setCanEditPublicProps(true); // Admins can edit public props
+      }
     });
   }, []);
 
@@ -257,9 +264,11 @@ export function CreateEditPropForm(
                           Personal
                         </SelectItem>
                       )}
-                    <SelectItem value="null">
-                      Public
-                    </SelectItem>
+                    {canEditPublicProps && (
+                      <SelectItem value="null">
+                        Public
+                      </SelectItem>
+                    )}
                   </SelectContent>
                 </Select>
                 <FormMessage />

--- a/components/forms/create-edit-prop-form.tsx
+++ b/components/forms/create-edit-prop-form.tsx
@@ -40,6 +40,9 @@ const formSchema = z.object({
   ),
   category_id: z.coerce.number(),
   year: z.coerce.number(),
+  user_id: z.string().optional().transform(
+    (value) => (value === "null" || value === undefined ? null : parseInt(value, 10)),
+  ).nullable(),
 });
 
 /*
@@ -47,7 +50,11 @@ const formSchema = z.object({
  * If initialProp is provided, the form will be in edit mode, otherwise in create mode.
  */
 export function CreateEditPropForm(
-  { initialProp, onSubmit }: { initialProp?: VProp; onSubmit?: () => void },
+  { initialProp, defaultUserId, onSubmit }: {
+    initialProp?: VProp;
+    defaultUserId?: number;
+    onSubmit?: () => void;
+  },
 ) {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(true);
@@ -61,9 +68,9 @@ export function CreateEditPropForm(
       notes: initialProp?.prop_notes || undefined,
       category_id: initialProp?.category_id,
       year: initialProp?.year,
+      user_id: initialProp?.prop_user_id || defaultUserId,
     },
   });
-
   useEffect(() => {
     getCategories().then(async (categories) => {
       setCategories(categories);
@@ -217,6 +224,39 @@ export function CreateEditPropForm(
                         {year}
                       </SelectItem>
                     ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            );
+          }}
+        />
+        <FormField
+          control={form.control}
+          name="user_id"
+          render={({ field }) => {
+            return (
+              <FormItem>
+                <FormLabel>Public/Personal</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  {...field}
+                  value={field.value ? field.value.toString() : "null"}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a type" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {defaultUserId && (
+                      <SelectItem value={defaultUserId.toString()}>
+                        Personal
+                      </SelectItem>
+                    )}
+                    <SelectItem value="null">
+                      Public
+                    </SelectItem>
                   </SelectContent>
                 </Select>
                 <FormMessage />

--- a/components/forms/create-edit-prop-form.tsx
+++ b/components/forms/create-edit-prop-form.tsx
@@ -41,7 +41,9 @@ const formSchema = z.object({
   category_id: z.coerce.number(),
   year: z.coerce.number(),
   user_id: z.string().optional().transform(
-    (value) => (value === "null" || value === undefined ? null : parseInt(value, 10)),
+    (
+      value,
+    ) => (value === "null" || value === undefined ? null : parseInt(value, 10)),
   ).nullable(),
 });
 

--- a/components/forms/create-edit-prop-form.tsx
+++ b/components/forms/create-edit-prop-form.tsx
@@ -40,7 +40,7 @@ const formSchema = z.object({
   ),
   category_id: z.coerce.number(),
   year: z.coerce.number(),
-  user_id: z.string().optional().transform(
+  user_id: z.coerce.string().optional().transform(
     (
       value,
     ) => (value === "null" || value === undefined ? null : parseInt(value, 10)),
@@ -63,6 +63,7 @@ export function CreateEditPropForm(
   const [categories, setCategories] = useState<Category[]>([]);
   const [years, setYears] = useState<number[]>([]);
   const { toast } = useToast();
+  const initialUserId = initialProp?.prop_user_id || defaultUserId;
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -70,14 +71,13 @@ export function CreateEditPropForm(
       notes: initialProp?.prop_notes || undefined,
       category_id: initialProp?.category_id,
       year: initialProp?.year,
-      user_id: initialProp?.prop_user_id || defaultUserId,
+      user_id: initialUserId,
     },
   });
   useEffect(() => {
     getCategories().then(async (categories) => {
       setCategories(categories);
       const years = await getPropYears();
-      years.unshift(years[0] + 1);
       setYears(years);
       setLoading(false);
     });
@@ -251,11 +251,12 @@ export function CreateEditPropForm(
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    {defaultUserId && (
-                      <SelectItem value={defaultUserId.toString()}>
-                        Personal
-                      </SelectItem>
-                    )}
+                    {initialUserId &&
+                      (
+                        <SelectItem value={initialUserId.toString()}>
+                          Personal
+                        </SelectItem>
+                      )}
                     <SelectItem value="null">
                       Public
                     </SelectItem>

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -74,8 +74,8 @@ export default async function NavBar() {
     });
     if (await hasFeatureEnabled({featureName: "personal-props", userId})) {
       forecastLinks.links.push({
-        href: `/props/2025/personal/user/${userId}`,
-        label: "Your 2025 Personal Props",
+        href: `/props/2025/user/${userId}`,
+        label: "Your Personal Props",
         icon: <User2 size={16} />,
       });
     }

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -23,8 +23,10 @@ import {
   Medal,
   MessageCircle,
   TrendingUpDown,
+  User2,
   Users,
 } from "lucide-react";
+import { hasFeatureEnabled } from "@/lib/db_actions";
 
 type NavLink = {
   href: string;
@@ -70,6 +72,13 @@ export default async function NavBar() {
       label: "Your 2025 Forecasts",
       icon: <TrendingUpDown size={14} />,
     });
+    if (await hasFeatureEnabled({featureName: "personal-props", userId})) {
+      forecastLinks.links.push({
+        href: `/props/2025/personal/user/${userId}`,
+        label: "Your 2025 Personal Props",
+        icon: <User2 size={16} />,
+      });
+    }
   }
   const adminLinks: NavLink[] = [
     { href: "/admin/users", label: "Users", icon: <Users size={16} /> },

--- a/components/pages/error-page.tsx
+++ b/components/pages/error-page.tsx
@@ -1,0 +1,16 @@
+import PageHeading from "@/components/page-heading";
+
+export default function ErrorPage(
+  { title, children }: { title: string; children?: React.ReactNode },
+) {
+  return (
+    <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
+      <div className="w-full max-w-lg">
+        <PageHeading title={title} />
+        <div className="flex flex-col justify-start items-start gap-3">
+          {children}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/components/tables/prop-table/create-new-prop-button.tsx
+++ b/components/tables/prop-table/create-new-prop-button.tsx
@@ -13,7 +13,10 @@ import { Button } from "@/components/ui/button";
 import { CreateEditPropForm } from "@/components/forms/create-edit-prop-form";
 
 export default function CreateNewPropButton(
-  { className, defaultUserId }: { className?: string; defaultUserId?: number },
+  { className, defaultUserId }: {
+    className?: string;
+    defaultUserId?: number;
+  },
 ) {
   const [open, setOpen] = useState(false);
   className = cn("gap-2", className);

--- a/components/tables/prop-table/create-new-prop-button.tsx
+++ b/components/tables/prop-table/create-new-prop-button.tsx
@@ -12,7 +12,9 @@ import {
 import { Button } from "@/components/ui/button";
 import { CreateEditPropForm } from "@/components/forms/create-edit-prop-form";
 
-export default function CreateNewPropButton({ className }: { className?: string }) {
+export default function CreateNewPropButton(
+  { className, defaultUserId }: { className?: string; defaultUserId?: number },
+) {
   const [open, setOpen] = useState(false);
   className = cn("gap-2", className);
   return (
@@ -27,7 +29,10 @@ export default function CreateNewPropButton({ className }: { className?: string 
         <DialogHeader>
           <DialogTitle>Create new prop</DialogTitle>
         </DialogHeader>
-        <CreateEditPropForm onSubmit={() => setOpen(false)} />
+        <CreateEditPropForm
+          onSubmit={() => setOpen(false)}
+          defaultUserId={defaultUserId}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/components/tables/prop-table/row.tsx
+++ b/components/tables/prop-table/row.tsx
@@ -38,6 +38,7 @@ export default function Row(
                     : resolveProp({
                       propId: row.prop_id,
                       resolution,
+                      userId: row.prop_user_id,
                       overwrite: true,
                       notes,
                     })}

--- a/components/tables/prop-table/table.tsx
+++ b/components/tables/prop-table/table.tsx
@@ -14,9 +14,12 @@ export interface PropTableSearchParams {
 interface PropTableProps {
   data: VProp[];
   editable: boolean;
+  defaultPropUserId?: number | undefined;
 }
 
-export function PropTable({ data, editable }: PropTableProps) {
+export function PropTable(
+  { data, editable, defaultPropUserId }: PropTableProps,
+) {
   const router = useRouter();
   const pathName = usePathname();
   const rawSearchParams = useSearchParams();
@@ -74,7 +77,12 @@ export function PropTable({ data, editable }: PropTableProps) {
           filter={searchParams}
           setFilter={updateSearchParams}
         />
-        {editable && <CreateNewPropButton className="mb-4" />}
+        {editable && (
+          <CreateNewPropButton
+            className="mb-4"
+            defaultUserId={defaultPropUserId}
+          />
+        )}
       </div>
       <ul className="w-full flex flex-col">
         {data.map((row) => (
@@ -86,5 +94,3 @@ export function PropTable({ data, editable }: PropTableProps) {
     </>
   );
 }
-
-

--- a/local-pg-container.yaml
+++ b/local-pg-container.yaml
@@ -4,12 +4,12 @@ services:
   postgres:
     image: postgres:17
     environment:
-      POSTGRES_USER: ethan
-      POSTGRES_PASSWORD: ethan
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: adminpw
       POSTGRES_DB: forecasting
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ethan -d forecasting"]
+      test: ["CMD-SHELL", "pg_isready -U admin -d forecasting"]
       interval: 3s
       timeout: 4s
       retries: 5
@@ -22,10 +22,11 @@ services:
       POSTGRES_USER: abc
       POSTGRES_PASSWORD: def
       POSTGRES_DB: nonsense
-      LOCAL_DB_URI: "postgresql://ethan:ethan@host.docker.internal:2345/forecasting"
+      LOCAL_DB_URI: "postgresql://admin:adminpw@host.docker.internal:2345/forecasting"
     depends_on:
       postgres:
         condition: service_healthy
     command: >
-      bash -c "pg_dump --no-owner --no-acl $DATABASE_URL | psql 'postgresql://ethan:ethan@host.docker.internal:2345/forecasting'"
+      bash -c "pg_dump --no-owner --no-acl $DATABASE_URL | psql 'postgresql://admin:adminpw@host.docker.internal:2345/forecasting'"
+
     

--- a/local-pg-container.yaml
+++ b/local-pg-container.yaml
@@ -1,11 +1,9 @@
-version: '3'
-
 services:
   postgres:
     image: postgres:17
     environment:
       POSTGRES_USER: admin
-      POSTGRES_PASSWORD: adminpw
+      POSTGRES_PASSWORD: admin_pw
       POSTGRES_DB: forecasting
     restart: always
     healthcheck:
@@ -22,11 +20,19 @@ services:
       POSTGRES_USER: abc
       POSTGRES_PASSWORD: def
       POSTGRES_DB: nonsense
-      LOCAL_DB_URI: "postgresql://admin:adminpw@host.docker.internal:2345/forecasting"
+      LOCAL_DB_URI: "postgresql://admin:admin_pw@host.docker.internal:2345/forecasting"
     depends_on:
       postgres:
         condition: service_healthy
     command: >
-      bash -c "pg_dump --no-owner --no-acl $DATABASE_URL | psql 'postgresql://admin:adminpw@host.docker.internal:2345/forecasting'"
-
-    
+      bash -c "
+        pg_dump --no-owner --no-acl $DATABASE_URL | psql 'postgresql://admin:admin_pw@host.docker.internal:2345/forecasting' &&
+        psql 'postgresql://admin:admin_pw@host.docker.internal:2345/forecasting' -c \"
+          CREATE ROLE app_user WITH LOGIN PASSWORD 'app_user_pw';
+          GRANT USAGE ON SCHEMA public TO app_user;
+          GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_user;
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user;
+          GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_user;
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO app_user;
+        \"
+      "

--- a/migrations/1742986038982_add-flag-personal-props.ts
+++ b/migrations/1742986038982_add-flag-personal-props.ts
@@ -1,0 +1,17 @@
+import type { Kysely } from 'kysely'
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function up(db: Kysely<any>): Promise<void> {
+	await db
+		.insertInto('feature_flags')
+		.values({ name: 'personal-props', user_id: 1, enabled: true })
+		.execute()
+}
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function down(db: Kysely<any>): Promise<void> {
+	await db
+		.deleteFrom('feature_flags')
+		.where('name', '=', 'personal-props')
+		.execute()
+}

--- a/migrations/1742986338172_alter-props-table-add-user-id-column.ts
+++ b/migrations/1742986338172_alter-props-table-add-user-id-column.ts
@@ -1,15 +1,15 @@
 import type { Kysely } from 'kysely'
 
 export async function up(db: Kysely<any>): Promise<void> {
-	await db
-		.insertInto('feature_flags')
-		.values({ name: 'personal-props', user_id: 1, enabled: true })
+	await db.schema
+		.alterTable('props')
+		.addColumn('user_id', 'integer', (col) => col.references('users.id'))
 		.execute()
 }
 
 export async function down(db: Kysely<any>): Promise<void> {
-	await db
-		.deleteFrom('feature_flags')
-		.where('name', '=', 'personal-props')
+	await db.schema
+		.alterTable('props')
+		.dropColumn('user_id')
 		.execute()
 }

--- a/migrations/1742987477096_enable-rls-on-props-table.ts
+++ b/migrations/1742987477096_enable-rls-on-props-table.ts
@@ -1,0 +1,57 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+	await sql<void>`ALTER TABLE props ENABLE ROW LEVEL SECURITY`.execute(db);
+	await sql<void>`
+		CREATE POLICY "Users can see their own props" ON props
+		USING (
+				props.user_id IS NULL
+			OR
+				props.user_id IS NOT NULL
+				AND current_setting('app.current_user_id', true) IS NOT NULL
+				AND props.user_id = current_setting('app.current_user_id', null)::INTEGER
+		)`
+		.execute(db);
+
+	// Update v_props to use the new policy and to include props.user_id.
+	await db.schema.dropView('v_props').execute();
+	await sql<void>`CREATE VIEW v_props WITH (security_barrier, security_invoker) AS
+		SELECT categories.id AS category_id,
+			categories.name AS category_name,
+			props.id AS prop_id,
+			props.text AS prop_text,
+			props.notes AS prop_notes,
+			props.year,
+			props.user_id as prop_user_id,
+			resolutions.id AS resolution_id,
+			resolutions.resolution,
+			resolutions.notes AS resolution_notes
+		FROM props
+			JOIN categories ON props.category_id = categories.id
+			LEFT JOIN resolutions ON props.id = resolutions.prop_id;
+	`
+		.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await db.schema.dropView('v_props').execute();
+	await sql<void>`CREATE VIEW v_props AS
+		SELECT categories.id AS category_id,
+			categories.name AS category_name,
+			props.id AS prop_id,
+			props.text AS prop_text,
+			props.notes AS prop_notes,
+			props.year,
+			resolutions.id AS resolution_id,
+			resolutions.resolution,
+			resolutions.notes AS resolution_notes
+		FROM props
+			JOIN categories ON props.category_id = categories.id
+			LEFT JOIN resolutions ON props.id = resolutions.prop_id;
+	`
+		.execute(db);
+	await sql<void>`DROP POLICY "Users can see their own props" ON props`
+		.execute(db);
+	await sql<void>`ALTER TABLE props DISABLE ROW LEVEL SECURITY`.execute(db);
+}

--- a/migrations/1742987477096_enable-rls-on-props-table.ts
+++ b/migrations/1742987477096_enable-rls-on-props-table.ts
@@ -26,14 +26,8 @@ export async function up(db: Kysely<any>): Promise<void> {
 	// Users can only update their own records.
 	await sql<void>`
 		CREATE POLICY "users_own_records" ON props
-		USING (
-				props.user_id IS NULL
-			OR
-				props.user_id IS NOT NULL AND current_user_id() = props.user_id
-		)
-		WITH CHECK (
-			props.user_id IS NOT NULL AND current_user_id() = props.user_id
-		);
+		USING (props.user_id IS NULL OR current_user_id() = props.user_id)
+		WITH CHECK (props.user_id IS NOT NULL AND current_user_id() = props.user_id);
 		`
 		.execute(db);
 	// Admins can read and write all records.

--- a/migrations/1742987477096_enable-rls-on-props-table.ts
+++ b/migrations/1742987477096_enable-rls-on-props-table.ts
@@ -10,6 +10,7 @@ export async function up(db: Kysely<any>): Promise<void> {
 			OR
 				props.user_id IS NOT NULL
 				AND current_setting('app.current_user_id', true) IS NOT NULL
+				AND current_setting('app.current_user_id', true) <> ''
 				AND props.user_id = current_setting('app.current_user_id', true)::INTEGER
 		)`
 		.execute(db);

--- a/migrations/1742987477096_enable-rls-on-props-table.ts
+++ b/migrations/1742987477096_enable-rls-on-props-table.ts
@@ -32,6 +32,7 @@ export async function up(db: Kysely<any>): Promise<void> {
 			LEFT JOIN resolutions ON props.id = resolutions.prop_id;
 	`
 		.execute(db);
+	await sql<void>`ALTER VIEW v_forecasts SET (security_barrier = true, security_invoker = true)`.execute(db);
 }
 
 export async function down(db: Kysely<any>): Promise<void> {

--- a/migrations/1742987477096_enable-rls-on-props-table.ts
+++ b/migrations/1742987477096_enable-rls-on-props-table.ts
@@ -2,26 +2,49 @@ import type { Kysely } from 'kysely'
 import { sql } from 'kysely'
 
 export async function up(db: Kysely<any>): Promise<void> {
-	await sql<void>`ALTER TABLE props ENABLE ROW LEVEL SECURITY`.execute(db);
+	// Add some helper functions to get the current user id and admin status.
 	await sql<void>`
-		CREATE POLICY "Users can see their own props" ON props
+		CREATE FUNCTION is_current_user_admin() RETURNS BOOLEAN AS $$
+		SELECT COALESCE(
+			(
+				SELECT is_admin
+				FROM users
+				WHERE id = NULLIF(current_setting('app.current_user_id', true), '')::INTEGER
+			),
+			false
+  )
+		$$ LANGUAGE sql STABLE SECURITY DEFINER;
+	`.execute(db);
+	await sql<void>`
+		CREATE FUNCTION current_user_id() RETURNS INTEGER AS $$
+			SELECT NULLIF(current_setting('app.current_user_id', true), '')::INTEGER;
+		$$ LANGUAGE sql STABLE SECURITY DEFINER;
+	`.execute(db);
+
+	await sql<void>`ALTER TABLE props ENABLE ROW LEVEL SECURITY`.execute(db);
+	// Users can view their own records and public records (where props.user_id is null).
+	// Users can only update their own records.
+	await sql<void>`
+		CREATE POLICY "users_own_records" ON props
 		USING (
 				props.user_id IS NULL
 			OR
-				CASE WHEN (
-					props.user_id IS NOT NULL
-					AND current_setting('app.current_user_id', true) IS NOT NULL
-					AND current_setting('app.current_user_id', true) <> ''
-				)
-				THEN
-					props.user_id = current_setting('app.current_user_id', true)::INTEGER
-				ELSE
-					FALSE
-				END
-		)`
+				props.user_id IS NOT NULL AND current_user_id() = props.user_id
+		)
+		WITH CHECK (
+			props.user_id IS NOT NULL AND current_user_id() = props.user_id
+		);
+		`
+		.execute(db);
+	// Admins can read and write all records.
+	await sql<void>`
+		CREATE POLICY admin_all_access ON props
+		USING (is_current_user_admin())
+		WITH CHECK (is_current_user_admin());
+	`
 		.execute(db);
 
-	// Update v_props to use the new policy and to include props.user_id.
+	// Update v_props to use the new policies and to include props.user_id.
 	await db.schema.dropView('v_props').execute();
 	await sql<void>`CREATE VIEW v_props WITH (security_barrier, security_invoker) AS
 		SELECT categories.id AS category_id,
@@ -60,7 +83,9 @@ export async function down(db: Kysely<any>): Promise<void> {
 			LEFT JOIN resolutions ON props.id = resolutions.prop_id;
 	`
 		.execute(db);
-	await sql<void>`DROP POLICY "Users can see their own props" ON props`
-		.execute(db);
+	await sql<void>`DROP POLICY "users_own_records" ON props`.execute(db);
+	await sql<void>`DROP POLICY "admin_all_access" ON props`.execute(db);
+	await sql<void>`DROP FUNCTION is_current_user_admin`.execute(db);
+	await sql<void>`DROP FUNCTION current_user_id`.execute(db);
 	await sql<void>`ALTER TABLE props DISABLE ROW LEVEL SECURITY`.execute(db);
 }

--- a/migrations/1742987477096_enable-rls-on-props-table.ts
+++ b/migrations/1742987477096_enable-rls-on-props-table.ts
@@ -10,7 +10,7 @@ export async function up(db: Kysely<any>): Promise<void> {
 			OR
 				props.user_id IS NOT NULL
 				AND current_setting('app.current_user_id', true) IS NOT NULL
-				AND props.user_id = current_setting('app.current_user_id', null)::INTEGER
+				AND props.user_id = current_setting('app.current_user_id', true)::INTEGER
 		)`
 		.execute(db);
 

--- a/migrations/1743086893944_alter-resolutions-table-add-user-id-column.ts
+++ b/migrations/1743086893944_alter-resolutions-table-add-user-id-column.ts
@@ -1,0 +1,97 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+	await db.schema
+		.alterTable('resolutions')
+		.addColumn('user_id', 'integer', (col) => col.references('users.id'))
+		.execute()
+	// Update v_props and v_forecasts to include resolutions.user_id as resolution_user_id.
+	await db.schema.dropView('v_props').execute();
+	await sql<void>`CREATE VIEW v_props WITH (security_barrier, security_invoker) AS
+		SELECT categories.id AS category_id,
+			categories.name AS category_name,
+			props.id AS prop_id,
+			props.text AS prop_text,
+			props.notes AS prop_notes,
+			props.year,
+			props.user_id as prop_user_id,
+			resolutions.id AS resolution_id,
+			resolutions.resolution,
+			resolutions.notes AS resolution_notes,
+			resolutions.user_id as resolution_user_id
+		FROM props
+			JOIN categories ON props.category_id = categories.id
+			LEFT JOIN resolutions ON props.id = resolutions.prop_id;
+	`.execute(db);
+	await db.schema.dropView('v_forecasts').execute();
+	await sql<void>`CREATE VIEW v_forecasts WITH (security_barrier, security_invoker) AS
+		SELECT users.id AS user_id,
+			users.name AS user_name,
+			categories.id AS category_id,
+			categories.name AS category_name,
+			props.id AS prop_id,
+			props.text AS prop_text,
+			props.notes AS prop_notes,
+			props.year,
+			forecasts.id AS forecast_id,
+			forecasts.forecast,
+			resolutions.id AS resolution_id,
+			resolutions.resolution,
+			resolutions.notes AS resolution_notes,
+			resolutions.user_id AS resolution_user_id,
+			power(resolutions.resolution::integer::double precision - forecasts.forecast, 2::double precision) AS score
+		FROM users
+			JOIN forecasts ON users.id = forecasts.user_id
+			JOIN props ON forecasts.prop_id = props.id
+			JOIN categories ON props.category_id = categories.id
+			LEFT JOIN resolutions ON props.id = resolutions.prop_id;
+	`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	// Revert v_props and v_forecasts to exclude resolutions.user_id.
+	await db.schema.dropView('v_props').execute();
+	await sql<void>`CREATE VIEW v_props WITH (security_barrier, security_invoker) AS
+		SELECT categories.id AS category_id,
+			categories.name AS category_name,
+			props.id AS prop_id,
+			props.text AS prop_text,
+			props.notes AS prop_notes,
+			props.year,
+			props.user_id as prop_user_id,
+			resolutions.id AS resolution_id,
+			resolutions.resolution,
+			resolutions.notes AS resolution_notes
+		FROM props
+			JOIN categories ON props.category_id = categories.id
+			LEFT JOIN resolutions ON props.id = resolutions.prop_id;
+	`.execute(db);
+	await db.schema.dropView('v_forecasts').execute();
+	await sql<void>`CREATE VIEW v_forecasts WITH (security_barrier, security_invoker) AS
+		SELECT users.id AS user_id,
+			users.name AS user_name,
+			categories.id AS category_id,
+			categories.name AS category_name,
+			props.id AS prop_id,
+			props.text AS prop_text,
+			props.notes AS prop_notes,
+			props.year,
+			forecasts.id AS forecast_id,
+			forecasts.forecast,
+			resolutions.id AS resolution_id,
+			resolutions.resolution,
+			resolutions.notes AS resolution_notes,
+			power(resolutions.resolution::integer::double precision - forecasts.forecast, 2::double precision) AS score
+		FROM users
+			JOIN forecasts ON users.id = forecasts.user_id
+			JOIN props ON forecasts.prop_id = props.id
+			JOIN categories ON props.category_id = categories.id
+			LEFT JOIN resolutions ON props.id = resolutions.prop_id;
+	`.execute(db);
+	// Drop the user_id column from the underlying resolutions table.
+	await db.schema
+		.alterTable('resolutions')
+		.dropColumn('user_id')
+		.execute()
+}

--- a/migrations/1743087634287_enable-rls-on-resolutions-table.ts
+++ b/migrations/1743087634287_enable-rls-on-resolutions-table.ts
@@ -1,0 +1,25 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+	await sql<void>`ALTER TABLE resolutions ENABLE ROW LEVEL SECURITY`.execute(db);
+	// Users can view their own records and public records (where resolutions.user_id is null).
+	// Users can only update their own records.
+	await sql<void>`
+		CREATE POLICY "users_own_records" ON resolutions
+		USING (resolutions.user_id IS NULL OR current_user_id() = resolutions.user_id)
+		WITH CHECK (resolutions.user_id IS NOT NULL AND current_user_id() = resolutions.user_id);
+	`.execute(db);
+	// Admins can read and write all records.
+	await sql<void>`
+		CREATE POLICY admin_all_access ON resolutions
+		USING (is_current_user_admin())
+		WITH CHECK (is_current_user_admin());
+	`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await sql<void>`DROP POLICY "users_own_records" ON resolutions;`.execute(db);
+	await sql<void>`DROP POLICY admin_all_access ON resolutions;`.execute(db);
+	await sql<void>`ALTER TABLE resolutions DISABLE ROW LEVEL SECURITY`.execute(db);
+}

--- a/migrations/1743088073468_set-security-barrier-and-invoker-on-views.ts
+++ b/migrations/1743088073468_set-security-barrier-and-invoker-on-views.ts
@@ -1,0 +1,18 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+const viewsToUpdate = ['v_feature_flags', 'v_password_reset_tokens', 'v_suggested_props', 'v_users']
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function up(db: Kysely<any>): Promise<void> {
+	for (const view of viewsToUpdate) {
+		await sql<void>`ALTER VIEW ${sql.id(view)} SET (security_barrier = true, security_invoker = true)`.execute(db);
+	}
+}
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function down(db: Kysely<any>): Promise<void> {
+	for (const view of viewsToUpdate) {
+		await sql<void>`ALTER VIEW ${sql.id(view)} RESET (security_barrier, security_invoker)`.execute(db);
+	}
+}

--- a/sql_scripts/create_app_user.sql
+++ b/sql_scripts/create_app_user.sql
@@ -1,0 +1,16 @@
+CREATE ROLE app_user WITH LOGIN PASSWORD '<redacted>';
+
+-- Basic privileges
+GRANT USAGE ON SCHEMA public TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_user;
+
+-- Future tables too
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_user;
+
+-- Grant privileges on sequences
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO app_user;
+
+-- For future sequences created by migrations
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO app_user;

--- a/types/db_types.ts
+++ b/types/db_types.ts
@@ -72,6 +72,7 @@ export interface ResolutionsTable {
   prop_id: number,
   resolution: boolean,
   notes: string | null,
+  user_id: number | null,
 }
 export type Resolution = Selectable<ResolutionsTable>
 export type NewResolution = Insertable<ResolutionsTable>
@@ -139,6 +140,7 @@ export interface VPropsView {
   year: number,
   resolution_id: number | null,
   resolution: boolean | null,
+  resolution_user_id: number | null,
   resolution_notes: string | null,
 }
 export type VProp = Selectable<VPropsView>
@@ -156,6 +158,7 @@ export interface VForecastsView {
   forecast: number,
   resolution_id: number | null,
   resolution: boolean | null,
+  resolution_user_id: number | null,
   resolution_notes: string | null,
   score: number | null,
 }

--- a/types/db_types.ts
+++ b/types/db_types.ts
@@ -51,6 +51,7 @@ export interface PropsTable {
   category_id: number,
   year: number,
   notes: string | null,
+  user_id: number | null,
 }
 export type Prop = Selectable<PropsTable>
 export type NewProp = Insertable<PropsTable>

--- a/types/db_types.ts
+++ b/types/db_types.ts
@@ -132,6 +132,7 @@ export interface VPropsView {
   prop_id: number,
   prop_text: string,
   prop_notes: string | null,
+  prop_user_id: number,
   category_id: number,
   category_name: string,
   year: number,


### PR DESCRIPTION
# Overview
This PR is large. Top level features:
- Add `user_id` columns on `propositions` and `resolutions` (and update related views `v_props` and `v_forecasts`)
- Enable Postgres Row-Level Security on those tables.
- Make public props/resolutions viewable by all but editable by admins only. Make user-scoped props/resolutions viewable and editable only by the owner and by admins.
- Create a new `/props/[year]/user/[user-id]` page to view and resolve user-scoped props

Other stuff
- Update all views with the `security_barrier` and `security_invoker` options, so that they honor the same RLS rules as the underlying tables
- Add a feature flag to make the new `/props/[year]/user/[user-id]` page visible to some users. Enable it only for user ID 1 (me).
- Add an "app_user" Postgres user for local development to better reflect the admin/app_user distinction in prod

# Impact
For now, users (except me) shouldn't see any differences on their end