### PR TITLE
Add created_at & updated_at; EnableRLS on forecasts

### DIFF
--- a/app/competitions/[competitionId]/forecasts/record/page.tsx
+++ b/app/competitions/[competitionId]/forecasts/record/page.tsx
@@ -26,7 +26,10 @@ export default async function RecordForecastsPage(
   // Mapping from category IDs to the props in that category.
   const propsByCategoryId: Map<(number | null), VProp[]> = new Map();
   // Mapping from category IDs to category objects.
-  const categories: Map<(number | null), (Category | null)> = new Map();
+  const categories: Map<
+    (number | null),
+    ({ id: number; name: string } | null)
+  > = new Map();
   props.forEach((prop) => {
     if (prop.category_id === null || prop.category_name === null) {
       if (!categories.has(null)) {
@@ -112,7 +115,10 @@ export default async function RecordForecastsPage(
 }
 
 function CategoryProps(
-  { category, props }: { category: Category | null; props: VProp[] },
+  { category, props }: {
+    category: { id: number; name: string } | null;
+    props: VProp[];
+  },
 ) {
   return (
     <div>

--- a/lib/db_actions/categories.ts
+++ b/lib/db_actions/categories.ts
@@ -1,8 +1,9 @@
 "use server";
+import { Category } from "@/types/db_types";
 import { getUserFromCookies } from "../get-user";
 import { db } from '@/lib/database';
 
-export async function getCategories(): Promise<{ id: number, name: string }[]> {
+export async function getCategories(): Promise<Category[]> {
   const currentUser = await getUserFromCookies();
   if (!currentUser) {
     throw new Error('Unauthorized');

--- a/lib/db_actions/forecasts.ts
+++ b/lib/db_actions/forecasts.ts
@@ -4,73 +4,83 @@ import { ForecastUpdate, NewForecast, VForecast, VProp } from '@/types/db_types'
 import { db } from '@/lib/database';
 import { getUserFromCookies } from '@/lib/get-user';
 import { revalidatePath } from 'next/cache';
+import { sql } from 'kysely';
 
 export async function getForecasts(
   { userId, competitionId }: { userId?: number, competitionId?: number } = {}
 ): Promise<VForecast[]> {
   const currentUser = await getUserFromCookies();
-  if (!currentUser) {
-    throw new Error('Unauthorized');
-  }
-  let query = db.selectFrom('v_forecasts').selectAll();
-  if (userId !== undefined) {
-    query = query.where('user_id', '=', userId);
-  }
-  if (competitionId !== undefined) {
-    query = query.where('competition_id', '=', competitionId);
-  }
-  return await query.execute();
+  return db.transaction().execute(async (trx) => {
+    await trx.executeQuery(sql`SELECT set_config('app.current_user_id', ${currentUser?.id}, true);`.compile(db));
+    let query = trx.selectFrom('v_forecasts').selectAll();
+    if (userId !== undefined) {
+      query = query.where('user_id', '=', userId);
+    }
+    if (competitionId !== undefined) {
+      query = query.where('competition_id', '=', competitionId);
+    }
+    return await query.execute();
+  });
 }
 
 export async function createForecast({ forecast }: { forecast: NewForecast }): Promise<number> {
-  // Make sure the user is who they say they.
-  const user = await getUserFromCookies();
-  if (!user || user.id !== forecast.user_id) {
-    throw new Error('Unauthorized');
-  }
-  // Only allow creating forecasts for future years.
-  const prop = await db
-    .selectFrom('v_props')
-    .where('prop_id', '=', forecast.prop_id)
-    .select('competition_forecasts_due_date')
-    .executeTakeFirst();
-  const dueDate = prop?.competition_forecasts_due_date;
-  if (dueDate && dueDate <= new Date()) {
-    throw new Error('Cannot create forecasts past the due date');
-  }
-  const { id } = await db
-    .insertInto('forecasts')
-    .values(forecast)
-    .returning('id')
-    .executeTakeFirstOrThrow();
+  const currentUser = await getUserFromCookies();
+  // Check that the competition hasn't ended already.
+  await db.transaction().execute(async (trx) => {
+    await trx.executeQuery(sql`SELECT set_config('app.current_user_id', ${currentUser?.id}, true);`.compile(db));
+    const prop = await trx
+      .selectFrom('v_props')
+      .where('prop_id', '=', forecast.prop_id)
+      .select('competition_forecasts_due_date')
+      .executeTakeFirst();
+    const dueDate = prop?.competition_forecasts_due_date;
+    if (dueDate && dueDate <= new Date()) {
+      throw new Error('Cannot create forecasts past the due date');
+    }
+  });
+  // Insert the record.
+  const id = db.transaction().execute(async (trx) => {
+    await trx.executeQuery(sql`SELECT set_config('app.current_user_id', ${currentUser?.id}, true);`.compile(db));
+    const { id } = await trx
+      .insertInto('forecasts')
+      .values(forecast)
+      .returning('id')
+      .executeTakeFirstOrThrow();
+    return id;
+  });
   revalidatePath('/forecasts');
   return id;
 }
 
 export async function updateForecast({ id, forecast }: { id: number, forecast: ForecastUpdate }): Promise<void> {
-  // Make sure the user is who they say they.
-  const user = await getUserFromCookies();
-  if (!user) throw new Error('Unauthorized');
   // Don't let users change any column except the forecast.
   if (Object.keys(forecast).length !== 1 || !('forecast' in forecast)) {
     console.log(`Attempted update with invalid columns: ${Object.keys(forecast)}`);
     throw new Error('Unauthorized');
   }
-  // Only allow creating forecasts for future years.
-  const prop = await db
-    .selectFrom('v_props')
-    .where('prop_id', '=', id)
-    .select('competition_forecasts_due_date')
-    .executeTakeFirst();
-  const dueDate = prop?.competition_forecasts_due_date;
-  if (dueDate && dueDate <= new Date()) {
-    throw new Error('Cannot create forecasts past the due date');
-  }
-  await db
-    .updateTable('forecasts')
-    .set(forecast)
-    .where('id', '=', id)
-    .execute();
+  const currentUser = await getUserFromCookies();
+  // Check that the competition hasn't ended already.
+  await db.transaction().execute(async (trx) => {
+    await trx.executeQuery(sql`SELECT set_config('app.current_user_id', ${currentUser?.id}, true);`.compile(db));
+    const prop = await trx
+      .selectFrom('v_props')
+      .where('prop_id', '=', id)
+      .select('competition_forecasts_due_date')
+      .executeTakeFirst();
+    const dueDate = prop?.competition_forecasts_due_date;
+    if (dueDate && dueDate <= new Date()) {
+      throw new Error('Cannot create forecasts past the due date');
+    }
+  });
+  // Update the record.
+  await db.transaction().execute(async (trx) => {
+    await trx.executeQuery(sql`SELECT set_config('app.current_user_id', ${currentUser?.id}, true);`.compile(db));
+    await trx
+      .updateTable('forecasts')
+      .set(forecast)
+      .where('id', '=', id)
+      .execute();
+  });
   revalidatePath('/forecasts');
 }
 
@@ -78,22 +88,21 @@ export async function getUnforecastedProps(
   { competitionId, userId }:
     { competitionId: number, userId: number }
 ): Promise<VProp[]> {
-  // Make sure the user is who they say they, or an admin.
-  const user = await getUserFromCookies();
-  if (!user) throw new Error('Unauthorized');
-  if (user.id !== userId && !user.is_admin) throw new Error('Unauthorized')
+  const currentUser = await getUserFromCookies();
   // Fetch props without a corresponding entry in the forecasts table for that user.
-  const propsForYear = await db.
-    selectFrom('v_props')
-    .selectAll()
-    .where('competition_id', '=', competitionId)
-    .where(({ not, exists, selectFrom }) => not(exists(
-      selectFrom('forecasts')
-        .select("id")
-        .where('user_id', '=', userId)
-        .whereRef('forecasts.prop_id', '=', 'v_props.prop_id')
-    )
-    ))
-    .execute();
-  return propsForYear;
+  return db.transaction().execute(async (trx) => {
+    await trx.executeQuery(sql`SELECT set_config('app.current_user_id', ${currentUser?.id}, true);`.compile(db));
+    return await db.
+      selectFrom('v_props')
+      .selectAll()
+      .where('competition_id', '=', competitionId)
+      .where(({ not, exists, selectFrom }) => not(exists(
+        selectFrom('forecasts')
+          .select("id")
+          .where('user_id', '=', userId)
+          .whereRef('forecasts.prop_id', '=', 'v_props.prop_id')
+      )
+      ))
+      .execute();
+  });
 }

--- a/migrations/1743559965925_alter-tables-add-updated-at-and-created-at-columns.ts
+++ b/migrations/1743559965925_alter-tables-add-updated-at-and-created-at-columns.ts
@@ -1,0 +1,56 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely';
+
+// This is all first-class entities in the DB. It excludes invite_tokens and
+// password_reset_tokens, since those are strictly created once and are consumed on use.
+const TABLES = [
+	"categories", "competitions", "feature_flags", "forecasts", "logins", "props",
+	"resolutions", "suggested_props", "users",
+]
+
+export async function up(db: Kysely<any>): Promise<void> {
+	// Create a function we can use as a trigger to set the updated_at column on every update.
+	await sql<void>`
+		CREATE OR REPLACE FUNCTION set_updated_at()
+		RETURNS TRIGGER AS $$
+		BEGIN
+			NEW.updated_at = now();
+			RETURN NEW;
+		END;
+		$$ LANGUAGE plpgsql;
+	`.execute(db);
+
+	for (const table of TABLES) {
+		// Create the updated_at and created_at columns.
+		await db.schema.alterTable(table)
+			.addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+			.addColumn('updated_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+			.execute();
+		// Add a trigger to set the updated_at column on every update.
+		await sql<void>`
+			CREATE TRIGGER set_updated_at
+			BEFORE INSERT OR UPDATE ON ${sql.id(table)}
+			FOR EACH ROW
+			EXECUTE FUNCTION set_updated_at();
+		`.execute(db);
+	}
+}
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function down(db: Kysely<any>): Promise<void> {
+	for (const table of TABLES) {
+		// Drop the new columns.
+		await db.schema.alterTable(table)
+			.dropColumn('created_at')
+			.dropColumn('updated_at')
+			.execute();
+		// Drop the trigger.
+		await sql<void>`
+			DROP TRIGGER set_updated_at ON ${sql.id(table)};
+		`.execute(db);
+	}
+	// Drop the function.
+	await sql<void>`
+		DROP FUNCTION set_updated_at();
+	`.execute(db);
+}

--- a/migrations/1743562246323_enable-rls-on-forecasts-table.ts
+++ b/migrations/1743562246323_enable-rls-on-forecasts-table.ts
@@ -7,7 +7,7 @@ export async function up(db: Kysely<any>): Promise<void> {
 	// Users can view *all* forecasts, at least for now.
 	// Users can only update their own forecasts.
 	await sql<void>`
-		CREATE POLICY "everyone_sees_all" ON forecasts
+		CREATE POLICY everyone_sees_all ON forecasts
 		USING (1 = 1)
 		WITH CHECK (current_user_id() = forecasts.user_id);
 	`.execute(db);
@@ -20,7 +20,7 @@ export async function up(db: Kysely<any>): Promise<void> {
 }
 
 export async function down(db: Kysely<any>): Promise<void> {
-	await sql<void>`DROP POLICY "users_own_records" ON forecasts;`.execute(db);
+	await sql<void>`DROP POLICY everyone_sees_all ON forecasts;`.execute(db);
 	await sql<void>`DROP POLICY admin_all_access ON forecasts;`.execute(db);
 	await sql<void>`ALTER TABLE forecasts DISABLE ROW LEVEL SECURITY`.execute(db);
 }

--- a/migrations/1743562246323_enable-rls-on-forecasts-table.ts
+++ b/migrations/1743562246323_enable-rls-on-forecasts-table.ts
@@ -1,0 +1,27 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+// `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
+export async function up(db: Kysely<any>): Promise<void> {
+	await sql<void>`ALTER TABLE forecasts ENABLE ROW LEVEL SECURITY`.execute(db);
+	// Users can view their own forecasts and public forecasts (where forecast.user_id
+	// is null).
+	// Users can only update their own forecasts.
+	await sql<void>`
+		CREATE POLICY "users_own_records" ON forecasts
+		USING (forecasts.user_id IS NULL OR current_user_id() = forecasts.user_id)
+		WITH CHECK (forecasts.user_id IS NOT NULL AND current_user_id() = forecasts.user_id);
+	`.execute(db);
+	// Admins can read and write all forecasts.
+	await sql<void>`
+		CREATE POLICY admin_all_access ON forecasts
+		USING (is_current_user_admin())
+		WITH CHECK (is_current_user_admin());
+	`.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+	await sql<void>`DROP POLICY "users_own_records" ON forecasts;`.execute(db);
+	await sql<void>`DROP POLICY admin_all_access ON forecasts;`.execute(db);
+	await sql<void>`ALTER TABLE forecasts DISABLE ROW LEVEL SECURITY`.execute(db);
+}

--- a/migrations/1743562246323_enable-rls-on-forecasts-table.ts
+++ b/migrations/1743562246323_enable-rls-on-forecasts-table.ts
@@ -4,13 +4,12 @@ import { sql } from 'kysely'
 // `any` is required here since migrations should be frozen in time. alternatively, keep a "snapshot" db interface.
 export async function up(db: Kysely<any>): Promise<void> {
 	await sql<void>`ALTER TABLE forecasts ENABLE ROW LEVEL SECURITY`.execute(db);
-	// Users can view their own forecasts and public forecasts (where forecast.user_id
-	// is null).
+	// Users can view *all* forecasts, at least for now.
 	// Users can only update their own forecasts.
 	await sql<void>`
-		CREATE POLICY "users_own_records" ON forecasts
-		USING (forecasts.user_id IS NULL OR current_user_id() = forecasts.user_id)
-		WITH CHECK (forecasts.user_id IS NOT NULL AND current_user_id() = forecasts.user_id);
+		CREATE POLICY "everyone_sees_all" ON forecasts
+		USING (1 = 1)
+		WITH CHECK (current_user_id() = forecasts.user_id);
 	`.execute(db);
 	// Admins can read and write all forecasts.
 	await sql<void>`

--- a/types/db_types.ts
+++ b/types/db_types.ts
@@ -33,6 +33,8 @@ export interface UsersTable {
   email: string,
   login_id: number | null,
   is_admin: boolean,
+  updated_at: Generated<Date>,
+  created_at: Generated<Date>,
 }
 export type User = Selectable<UsersTable>
 export type NewUser = Insertable<UsersTable>
@@ -41,6 +43,8 @@ export type UserUpdate = Updateable<UsersTable>
 export interface CategoriesTable {
   id: Generated<number>,
   name: string,
+  updated_at: Generated<Date>,
+  created_at: Generated<Date>,
 }
 export type Category = Selectable<CategoriesTable>
 export type NewCategory = Insertable<CategoriesTable>
@@ -53,6 +57,8 @@ export interface PropsTable {
   notes: string | null,
   user_id: number | null,
   competition_id: number | null,
+  updated_at: Generated<Date>,
+  created_at: Generated<Date>,
 }
 export type Prop = Selectable<PropsTable>
 export type NewProp = Insertable<PropsTable>
@@ -63,6 +69,8 @@ export interface ForecastsTable {
   prop_id: number,
   user_id: number,
   forecast: number,
+  updated_at: Generated<Date>,
+  created_at: Generated<Date>,
 }
 export type Forecast = Selectable<ForecastsTable>
 export type NewForecast = Insertable<ForecastsTable>
@@ -74,6 +82,8 @@ export interface ResolutionsTable {
   resolution: boolean,
   notes: string | null,
   user_id: number | null,
+  updated_at: Generated<Date>,
+  created_at: Generated<Date>,
 }
 export type Resolution = Selectable<ResolutionsTable>
 export type NewResolution = Insertable<ResolutionsTable>
@@ -83,6 +93,8 @@ export interface LoginsTable {
   id: Generated<number>,
   username: string,
   password_hash: string,
+  updated_at: Generated<Date>,
+  created_at: Generated<Date>,
 }
 export type Login = Selectable<LoginsTable>
 export type NewLogin = Insertable<LoginsTable>
@@ -92,6 +104,8 @@ export interface SuggestedPropsTable {
   id: Generated<number>,
   suggester_user_id: number,
   prop: string,
+  updated_at: Generated<Date>,
+  created_at: Generated<Date>,
 }
 export type SuggestedProp = Selectable<SuggestedPropsTable>
 export type NewSuggestedProp = Insertable<SuggestedPropsTable>
@@ -102,6 +116,8 @@ export interface FeatureFlagsTable {
   name: string,
   user_id: number | null,
   enabled: boolean,
+  updated_at: Generated<Date>,
+  created_at: Generated<Date>,
 }
 export type FeatureFlag = Selectable<FeatureFlagsTable>
 export type NewFeatureFlag = Insertable<FeatureFlagsTable>
@@ -134,6 +150,8 @@ export interface CompetitionsTable {
   name: string,
   forecasts_due_date: Date,
   end_date: Date,
+  updated_at: Generated<Date>,
+  created_at: Generated<Date>,
 }
 export type Competition = Selectable<CompetitionsTable>
 export type NewCompetition = Insertable<CompetitionsTable>


### PR DESCRIPTION
This adds `created_at` and `updated_at` to all tables, and enables RLS on `forecasts`.

It also updated DB types and DB functions to accommodate this.