### PR TITLE
Improve API fetch helpers and reuse SWR for prop form data

### DIFF
--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { getCategories } from "@/lib/db_actions";
+import { getUserFromCookies } from "@/lib/get-user";
+
+export async function GET() {
+  try {
+    const user = await getUserFromCookies();
+
+    if (!user) {
+      return NextResponse.json({ categories: [] }, { status: 401 });
+    }
+
+    const categories = await getCategories();
+    return NextResponse.json({ categories });
+  } catch (error) {
+    console.error("Failed to load categories", error);
+    return NextResponse.json({ error: "Failed to load categories" }, { status: 500 });
+  }
+}

--- a/app/api/competitions/route.ts
+++ b/app/api/competitions/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { getCompetitions } from "@/lib/db_actions";
+import { getUserFromCookies } from "@/lib/get-user";
+
+export async function GET() {
+  try {
+    const user = await getUserFromCookies();
+
+    if (!user) {
+      return NextResponse.json({ competitions: [] }, { status: 401 });
+    }
+
+    const competitions = await getCompetitions();
+    return NextResponse.json({ competitions });
+  } catch (error) {
+    console.error("Failed to load competitions", error);
+    return NextResponse.json({ error: "Failed to load competitions" }, { status: 500 });
+  }
+}

--- a/app/api/current-user/route.ts
+++ b/app/api/current-user/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { getUserFromCookies } from "@/lib/get-user";
+
+export async function GET() {
+  const user = await getUserFromCookies();
+
+  if (!user) {
+    return NextResponse.json({ user: null }, { status: 401 });
+  }
+
+  return NextResponse.json({ user });
+}

--- a/hooks/useCategories.ts
+++ b/hooks/useCategories.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import useSWRImmutable from "swr/immutable";
+import type { Category } from "@/types/db_types";
+import { fetchJson, HttpError } from "@/lib/http";
+
+type CategoriesResponse = {
+  categories: Category[];
+};
+
+export function useCategories() {
+  return useSWRImmutable<Category[], HttpError>(
+    "/api/categories",
+    async (url) => {
+      const data = await fetchJson<CategoriesResponse>(url);
+      return data.categories;
+    },
+    {
+      shouldRetryOnError: false,
+    },
+  );
+}

--- a/hooks/useCompetitions.ts
+++ b/hooks/useCompetitions.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import useSWRImmutable from "swr/immutable";
+import type { Competition } from "@/types/db_types";
+import { fetchJson, HttpError } from "@/lib/http";
+
+type CompetitionsResponse = {
+  competitions: Competition[];
+};
+
+export function useCompetitions() {
+  return useSWRImmutable<Competition[], HttpError>(
+    "/api/competitions",
+    async (url) => {
+      const data = await fetchJson<CompetitionsResponse>(url);
+      return data.competitions;
+    },
+    {
+      shouldRetryOnError: false,
+    },
+  );
+}

--- a/hooks/useCurrentUser.ts
+++ b/hooks/useCurrentUser.ts
@@ -1,15 +1,34 @@
 "use client";
 
-import { getUserFromCookies } from "@/lib/get-user";
 import useSWR from "swr";
+import type { VUser } from "@/types/db_types";
+import { fetchJson, HttpError, isHttpError } from "@/lib/http";
+
+async function fetchCurrentUser(): Promise<VUser | null> {
+  try {
+    const data = await fetchJson<{ user: VUser | null }>("/api/current-user", {
+      cache: "no-store",
+    });
+    return data.user;
+  } catch (error) {
+    if (isHttpError(error) && error.status === 401) {
+      return null;
+    }
+    throw error;
+  }
+}
 
 export function useCurrentUser() {
-  const { data, isLoading, error, mutate } = useSWR(
-    "currentUser",
-    getUserFromCookies,
+  const { data, isLoading, error, mutate } = useSWR<VUser | null, HttpError>(
+    "/api/current-user",
+    fetchCurrentUser,
+    {
+      shouldRetryOnError: false,
+    },
   );
+
   return {
-    user: data,
+    user: data ?? null,
     isLoading,
     error,
     mutate,

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -1,0 +1,59 @@
+export class HttpError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown = null) {
+    super(message);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export function isHttpError(error: unknown): error is HttpError {
+  return error instanceof HttpError;
+}
+
+export async function fetchJson<T>(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+): Promise<T> {
+  const headers = new Headers(init.headers ?? undefined);
+
+  if (!headers.has("Accept")) {
+    headers.set("Accept", "application/json");
+  }
+
+  const response = await fetch(input, {
+    ...init,
+    headers,
+    credentials: init.credentials ?? "include",
+  });
+
+  let parsedBody: unknown = null;
+
+  if (response.status !== 204) {
+    const text = await response.text();
+
+    if (text) {
+      try {
+        parsedBody = JSON.parse(text);
+      } catch {
+        parsedBody = text;
+      }
+    }
+  }
+
+  if (!response.ok) {
+    const message =
+      typeof parsedBody === "object" &&
+      parsedBody !== null &&
+      "error" in parsedBody &&
+      typeof (parsedBody as { error?: unknown }).error === "string"
+        ? (parsedBody as { error: string }).error
+        : response.statusText || "Request failed";
+
+    throw new HttpError(message, response.status, parsedBody);
+  }
+
+  return parsedBody as T;
+}


### PR DESCRIPTION
## Summary
- add a shared HTTP helper that wraps JSON fetches with consistent headers, credential handling, and typed errors
- update the current-user hook to use the helper and add dedicated SWR hooks for categories and competitions
- refactor the create/edit prop form to consume the new hooks, surface loading and authorization errors, and reuse cached options

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6895ab854832da0cf2c50b4889849