### PR TITLE
Rename middleware.ts to proxy.ts for Next.js 16

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -21,7 +21,7 @@ function isPublicRoute(pathname: string): boolean {
   );
 }
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Allow public routes


### PR DESCRIPTION
## Summary

- Rename `middleware.ts` → `proxy.ts`
- Rename exported function `middleware` → `proxy`

This addresses the Next.js 16 deprecation warning:
```
⚠ The "middleware" file convention is deprecated. Please use "proxy" instead.
```

## Test plan

- [x] Build passes
- [x] Deprecation warning no longer appears
- [x] Auth redirects still work (unauthenticated users redirected to /login)

🤖 Generated with [Claude Code](https://claude.ai/code)