### PR TITLE
Redesign scores page with new ScoreCard component

### DIFF
--- a/components/charts/leaderboard-chart.tsx
+++ b/components/charts/leaderboard-chart.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Card, CardContent } from "@/components/ui/card";
-import { Category } from "@/types/db_types";
-import { CompetitionScore } from "@/lib/db_actions";
+import type { Category } from "@/types/db_types";
+import type { CompetitionScore } from "@/lib/db_actions";
 import ScoreCard from "@/components/scores/score-card";
 
 interface LeaderboardChartProps {

--- a/components/scores/score-card.tsx
+++ b/components/scores/score-card.tsx
@@ -11,8 +11,8 @@ import {
   ResponsiveContainer,
   Cell,
 } from "recharts";
-import { UserCategoryScore } from "@/lib/db_actions/competition-scores";
-import { Category } from "@/types/db_types";
+import type { UserCategoryScore } from "@/lib/db_actions/competition-scores";
+import type { Category } from "@/types/db_types";
 
 interface ScoreCardProps {
   rank: number;
@@ -89,17 +89,17 @@ export default function ScoreCard({
   competitionId,
   maxScore,
 }: ScoreCardProps) {
+  // Build category lookup map for O(1) access
+  const categoryMap = new Map(categories.map((c) => [c.id, c.name]));
+
   // Build chart data with Overall first, then categories
   const chartData: ChartDataItem[] = [
     { name: "Overall", score: overallScore, isOverall: true },
-    ...categoryScores.map((cs) => {
-      const category = categories.find((c) => c.id === cs.categoryId);
-      return {
-        name: category?.name || "Unknown",
-        score: cs.score,
-        isOverall: false,
-      };
-    }),
+    ...categoryScores.map((cs) => ({
+      name: categoryMap.get(cs.categoryId) || "Unknown",
+      score: cs.score,
+      isOverall: false,
+    })),
   ];
 
   return (
@@ -112,17 +112,19 @@ export default function ScoreCard({
           {/* Mobile layout */}
           <div className="flex flex-col md:hidden">
             {/* Top row: name/score on left, link on right */}
-            <div className="flex items-center justify-between">
-              <div className="flex items-baseline gap-2">
-                <span className="text-lg text-muted-foreground">{rank}.</span>
-                <span className="text-lg font-semibold truncate">
+            <div className="flex items-center justify-between min-w-0">
+              <div className="flex items-baseline gap-2 min-w-0 flex-1">
+                <span className="text-lg text-muted-foreground shrink-0">
+                  {rank}.
+                </span>
+                <span className="text-lg font-semibold truncate min-w-0 flex-1">
                   {userName}
                 </span>
-                <span className="text-xl font-bold ml-2">
+                <span className="text-xl font-bold ml-2 shrink-0">
                   {overallScore.toFixed(2)}
                 </span>
               </div>
-              <ChevronRight className="h-5 w-5 text-muted-foreground" />
+              <ChevronRight className="h-5 w-5 text-muted-foreground shrink-0" />
             </div>
             {/* Chart below */}
             <div className="h-28 mt-3">
@@ -136,15 +138,17 @@ export default function ScoreCard({
           </div>
 
           {/* Desktop layout */}
-          <div className="hidden md:flex items-center gap-4">
+          <div className="hidden md:flex items-center gap-4 min-w-0">
             {/* Left side: rank, name, score, link */}
-            <div className="flex flex-col w-1/3">
-              <div className="flex items-baseline gap-2">
-                <span className="text-lg text-muted-foreground">{rank}.</span>
-                <span className="text-lg font-semibold truncate">
+            <div className="flex flex-col w-1/3 min-w-0">
+              <div className="flex items-baseline gap-2 min-w-0">
+                <span className="text-lg text-muted-foreground shrink-0">
+                  {rank}.
+                </span>
+                <span className="text-lg font-semibold truncate flex-1 min-w-0">
                   {userName}
                 </span>
-                <span className="text-xl font-bold ml-2">
+                <span className="text-xl font-bold ml-2 shrink-0">
                   {overallScore.toFixed(2)}
                 </span>
               </div>


### PR DESCRIPTION
## Summary
- Create new ScoreCard component with horizontal bar chart using Recharts
- Show rank, name, overall score with category score bars
- Responsive layout: mobile shows stacked layout with chart below, desktop shows 1/3 info + 2/3 chart side-by-side
- Entire card is clickable to navigate to user's full score breakdown
- Simplified explanation text (removed heading)
- Extract reusable ScoreBarChart subcomponent for DRY code
- Add accessibility improvements (aria-label on links)

## Test plan
- [x] Verify desktop layout shows 1/3 + 2/3 split with all bar labels visible
- [x] Verify mobile layout shows info row with chevron, chart below
- [x] Verify clicking card navigates to score breakdown page
- [x] Verify bar chart scales correctly across different users/scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)