### PR TITLE
Simplify Account Settings page layout

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,6 +1,5 @@
 import PageHeading from "@/components/page-heading";
 import { AccountDetails } from "./account-details";
-import { User } from "lucide-react";
 
 export default async function Page() {
   const idpBaseUrl = process.env.IDP_BASE_URL;
@@ -8,9 +7,7 @@ export default async function Page() {
     <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
       <div className="w-full max-w-lg flex flex-col">
         <PageHeading
-          title="Account & Settings"
-          icon={User}
-          iconGradient="bg-gradient-to-br from-blue-500 to-indigo-600"
+          title="Account Settings"
           className="mb-2"
         />
         <AccountDetails idpBaseUrl={idpBaseUrl} />


### PR DESCRIPTION
## Summary
- Rename page from "Account & Settings" to "Account Settings"
- Remove icon from page heading
- Remove editable User Details section and "Account Details" heading
- Display user's name between username and email (if available)
- Improve spacing between avatar and text fields

## Test plan
- [x] Visit the Account Settings page while logged in
- [x] Verify page title shows "Account Settings" without an icon
- [x] Verify avatar, username, name, and email display correctly
- [x] Verify spacing looks correct between avatar and text fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)