### PR TITLE
Add competition admin role support and edit button for props

### DIFF
--- a/app/competitions/[competitionId]/props/[propId]/competition-prop-view.tsx
+++ b/app/competitions/[competitionId]/props/[propId]/competition-prop-view.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { ChevronRight, Calendar, CalendarClock, Lock } from "lucide-react";
+import { ChevronRight, Calendar, CalendarClock, Lock, Pencil } from "lucide-react";
 import { PropWithUserForecast } from "@/types/db_types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -253,6 +253,17 @@ export function CompetitionPropView({
                 </p>
               )}
             </div>
+            {isAdmin && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setIsEditDialogOpen(true)}
+                className="shrink-0"
+              >
+                <Pencil className="h-3.5 w-3.5 mr-1.5" />
+                Edit
+              </Button>
+            )}
           </div>
 
           {/* Deadline info */}

--- a/app/competitions/[competitionId]/props/[propId]/page.tsx
+++ b/app/competitions/[competitionId]/props/[propId]/page.tsx
@@ -58,21 +58,20 @@ async function CompetitionPropPageContent({
   }
   const competition = competitionResult.data;
 
-  // For private competitions, verify membership
-  if (competition.is_private) {
-    const roleResult = await getCurrentUserRole(competitionId);
-    if (!roleResult.success) {
-      return <ErrorPage title={roleResult.error} />;
-    }
+  const roleResult = await getCurrentUserRole(competitionId);
+  if (!roleResult.success) {
+    return <ErrorPage title={roleResult.error} />;
+  }
+  const userRole = roleResult.data;
 
-    if (roleResult.data === null) {
-      return (
-        <InaccessiblePage
-          title="Private Competition"
-          message="You are not a member of this competition."
-        />
-      );
-    }
+  // For private competitions, verify membership
+  if (competition.is_private && userRole === null) {
+    return (
+      <InaccessiblePage
+        title="Private Competition"
+        message="You are not a member of this competition."
+      />
+    );
   }
 
   // Get the prop with user's forecast
@@ -102,7 +101,7 @@ async function CompetitionPropPageContent({
       competitionId={competitionId}
       competitionName={competition.name}
       isForecastingOpen={isForecastingOpen}
-      isAdmin={user.is_admin}
+      isAdmin={user.is_admin || userRole === "admin"}
     />
   );
 }


### PR DESCRIPTION
## Summary
This PR extends admin access control to include competition-level admins (in addition to global admins) and adds an edit button to the prop view for admins.

## Key Changes
- **Refactored access control logic**: Moved `getCurrentUserRole()` call outside the private competition check so the user's role is always retrieved and available for authorization decisions
- **Extended admin privileges**: Updated the `isAdmin` prop to recognize both global admins (`user.is_admin`) and competition admins (`userRole === "admin"`)
- **Added edit functionality**: Added an "Edit" button to the prop view that appears only for admins, with a pencil icon from lucide-react
- **Simplified private competition check**: Consolidated the role verification logic to be more concise while maintaining the same behavior

## Implementation Details
- The role is now fetched unconditionally and stored in `userRole` variable for reuse
- Private competition access check now explicitly verifies `competition.is_private && userRole === null`
- The edit button uses the existing `setIsEditDialogOpen` state to trigger the edit dialog
- Button styling uses outline variant with small size to maintain visual consistency

https://claude.ai/code/session_013LjY2hYrqzHmZi4fmYxyTz