### PR TITLE
Add Edit button to the standalone prop page

### DIFF
--- a/app/props/[propId]/page.tsx
+++ b/app/props/[propId]/page.tsx
@@ -1,4 +1,5 @@
 import { getForecasts, getPropById } from "@/lib/db_actions";
+import { getCurrentUserRole } from "@/lib/db_actions/competition-members";
 import { getUserFromCookies } from "@/lib/get-user";
 import { Suspense } from "react";
 import ErrorPage from "@/components/pages/error-page";
@@ -60,6 +61,17 @@ async function PropPageContent({
   // Find user's forecast
   const userForecast = forecasts.find((f) => f.user_id === user.id);
 
+  // Determine if the user is an admin of this prop's competition (if any)
+  let isCompetitionAdmin = false;
+  if (prop.competition_id !== null) {
+    const roleResult = await getCurrentUserRole(prop.competition_id);
+    if (roleResult.success && roleResult.data === "admin") {
+      isCompetitionAdmin = true;
+    }
+  }
+  const canEdit =
+    user.is_admin || isCompetitionAdmin || prop.prop_user_id === user.id;
+
   // Calculate stats
   const forecastValues = forecasts.map((f) => f.forecast);
   const average =
@@ -76,6 +88,7 @@ async function PropPageContent({
         <PropPageHeader
           prop={prop}
           canResolve={user.is_admin || prop.prop_user_id === user.id}
+          canEdit={canEdit}
         />
 
         {/* Stats Row */}

--- a/app/props/[propId]/prop-page-header.tsx
+++ b/app/props/[propId]/prop-page-header.tsx
@@ -5,8 +5,9 @@ import { useRouter } from "next/navigation";
 import { VProp } from "@/types/db_types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ChevronLeft, CheckCircle2 } from "lucide-react";
+import { ChevronLeft, CheckCircle2, Pencil } from "lucide-react";
 import { ResolutionDialog } from "@/components/dialogs/resolution-dialog";
+import { PropEditDialog } from "@/components/dialogs/prop-edit-dialog";
 import { MarkdownRenderer } from "@/components/markdown";
 import { PropStatusBadge } from "@/components/ui/prop-status-badge";
 import { getPropStatusFromProp } from "@/lib/prop-status";
@@ -14,14 +15,17 @@ import { getPropStatusFromProp } from "@/lib/prop-status";
 interface PropPageHeaderProps {
   prop: VProp;
   canResolve: boolean;
+  canEdit: boolean;
 }
 
 export default function PropPageHeader({
   prop,
   canResolve,
+  canEdit,
 }: PropPageHeaderProps) {
   const router = useRouter();
   const [isResolutionDialogOpen, setIsResolutionDialogOpen] = useState(false);
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
 
   return (
     <>
@@ -45,17 +49,28 @@ export default function PropPageHeader({
             )}
             <PropStatusBadge status={getPropStatusFromProp(prop)} />
           </div>
-          {canResolve && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setIsResolutionDialogOpen(true)}
-              className="shrink-0"
-            >
-              <CheckCircle2 className="h-4 w-4 mr-2" />
-              Resolve
-            </Button>
-          )}
+          <div className="flex items-center gap-2 shrink-0">
+            {canEdit && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setIsEditDialogOpen(true)}
+              >
+                <Pencil className="h-4 w-4 mr-2" />
+                Edit
+              </Button>
+            )}
+            {canResolve && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setIsResolutionDialogOpen(true)}
+              >
+                <CheckCircle2 className="h-4 w-4 mr-2" />
+                Resolve
+              </Button>
+            )}
+          </div>
         </div>
         <h1 className="text-2xl font-bold text-foreground mb-2">
           <MarkdownRenderer>{prop.prop_text}</MarkdownRenderer>
@@ -81,6 +96,15 @@ export default function PropPageHeader({
         prop={prop}
         isOpen={isResolutionDialogOpen}
         onClose={() => setIsResolutionDialogOpen(false)}
+      />
+
+      <PropEditDialog
+        prop={prop}
+        isOpen={isEditDialogOpen}
+        onClose={() => {
+          setIsEditDialogOpen(false);
+          router.refresh();
+        }}
       />
     </>
   );


### PR DESCRIPTION
## Summary
Follow-up to #133 — adds an **Edit** button to the standalone prop page at `/props/[propId]`, which is used when forecasting on a prop is closed. That page already had a `Resolve` button but no way to edit, so competition admins still couldn't edit closed props from the UI.

## Changes
- `app/props/[propId]/prop-page-header.tsx` — accept a new `canEdit` prop and render an Edit button (mirroring the existing Resolve button) that opens the existing `PropEditDialog`.
- `app/props/[propId]/page.tsx` — compute `canEdit` to match the RLS policy: system admin OR competition admin (when the prop belongs to a competition) OR the prop's owner. Looks up the user's competition role via `getCurrentUserRole` only when the prop has a `competition_id`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — no new errors
- [x] `npx vitest run` — 192 tests pass
- [ ] Manual: as a competition admin (non-system-admin), open a closed prop and verify the Edit button appears and opens the edit dialog
- [ ] Manual: as a non-admin forecaster, verify the Edit button does not appear

https://claude.ai/code/session_013LjY2hYrqzHmZi4fmYxyTz

---
_Generated by [Claude Code](https://claude.ai/code/session_013LjY2hYrqzHmZi4fmYxyTz)_