### PR TITLE
Navbar wordmark: replace ghost-button brand with a gauge mark

### DIFF
--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -36,6 +36,7 @@ import { getCompetitionStatusFromObject } from "@/lib/competition-status";
 import { NavLink, NavLinkGroup, NavLinkSection } from "./nav-types";
 import { DropdownNavbarItem } from "./dropdown-navbar-item";
 import { MobileDropdownItem } from "./mobile-dropdown-item";
+import { Wordmark } from "./wordmark";
 
 export default function NavBar() {
   const { user, isLoading } = useCurrentUser();
@@ -137,10 +138,12 @@ export default function NavBar() {
       <nav className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-5 sm:px-6 lg:px-8">
           <div className="flex items-center space-x-4">
-            <Link href="/">
-              <Button variant="ghost" className="font-semibold text-lg">
-                Forecasting
-              </Button>
+            <Link
+              href="/"
+              aria-label="Forecasting home"
+              className="inline-flex items-center rounded-md px-2 py-1.5 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            >
+              <Wordmark />
             </Link>
           </div>
           <div className="flex items-center space-x-2">
@@ -174,13 +177,12 @@ export default function NavBar() {
                 <SheetHeader>
                   <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
                   <SheetClose asChild>
-                    <Link href="/">
-                      <Button
-                        variant="ghost"
-                        className="w-full justify-start h-12 text-lg font-semibold p-0"
-                      >
-                        Forecasting
-                      </Button>
+                    <Link
+                      href="/"
+                      aria-label="Forecasting home"
+                      className="flex w-full items-center rounded-md px-2 py-2 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                    >
+                      <Wordmark />
                     </Link>
                   </SheetClose>
                 </SheetHeader>
@@ -211,10 +213,12 @@ export default function NavBar() {
             </Sheet>
           )}
 
-          <Link href="/">
-            <Button variant="ghost" className="font-semibold text-lg ">
-              Forecasting
-            </Button>
+          <Link
+            href="/"
+            aria-label="Forecasting home"
+            className="inline-flex items-center rounded-md px-2 py-1.5 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          >
+            <Wordmark />
           </Link>
 
           {user && (

--- a/components/navbar/wordmark.stories.tsx
+++ b/components/navbar/wordmark.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Wordmark } from "./wordmark";
+
+const meta = {
+  title: "Navbar/Wordmark",
+  component: Wordmark,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof Wordmark>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// The brand mark as it appears in the navbar. Toggle the Storybook theme to
+// check the dark variant — the glyph is token-colored.
+export const Default: Story = {};
+
+// Sanity-check contrast on a muted surface (e.g. inside a hovered nav link).
+export const OnMutedSurface: Story = {
+  render: () => (
+    <div className="inline-flex rounded-md bg-muted px-2 py-1.5">
+      <Wordmark />
+    </div>
+  ),
+};

--- a/components/navbar/wordmark.tsx
+++ b/components/navbar/wordmark.tsx
@@ -1,0 +1,69 @@
+import { cn } from "@/lib/utils";
+
+interface WordmarkProps {
+  className?: string;
+}
+
+/**
+ * The "Forecasting" brand mark: a small gauge glyph that echoes the
+ * ForecastNeedle (a hairline arc + a single indigo needle + hub) followed by
+ * the wordmark set in semibold, tight-tracked sans.
+ *
+ * Pure presentational leaf — no router/db coupling — so the navbar supplies the
+ * surrounding <Link>, and it's trivial to render in Storybook.
+ */
+export function Wordmark({ className }: WordmarkProps) {
+  return (
+    <span
+      className={cn("inline-flex select-none items-center gap-2", className)}
+    >
+      <GaugeGlyph />
+      <span className="text-base font-semibold tracking-tight text-foreground">
+        Forecasting
+      </span>
+    </span>
+  );
+}
+
+/**
+ * A miniature gauge: a calm hairline band with one indigo needle. Colors are
+ * all design tokens so it adapts to light/dark automatically. Deliberately
+ * monochrome+indigo (no red→green likelihood gradient) to stay minimal.
+ */
+function GaugeGlyph() {
+  return (
+    <svg
+      viewBox="0 0 22 20"
+      className="h-5 w-[22px] shrink-0 overflow-visible"
+      aria-hidden="true"
+    >
+      {/* Gauge band */}
+      <path
+        d="M 3 15 A 8 8 0 0 1 19 15"
+        fill="none"
+        stroke="var(--muted-foreground)"
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+      {/* Needle — the single indigo accent, pointing up and to the right */}
+      <line
+        x1={11}
+        y1={15}
+        x2={14.5}
+        y2={8.2}
+        stroke="var(--primary)"
+        strokeWidth={2.5}
+        strokeLinecap="round"
+      />
+      {/* Hub */}
+      <circle
+        cx={11}
+        cy={15}
+        r={2}
+        fill="var(--background)"
+        stroke="var(--foreground)"
+        strokeWidth={1.5}
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## What

Replaces the `text-lg` ghost-**button** "Forecasting" brand in the navbar with a proper, reusable **wordmark**: a small monochrome gauge glyph (hairline arc + a single indigo needle + hub) that echoes the product's signature `ForecastNeedle`, followed by the wordmark in semibold, tight-tracked Geist Sans.

This is the first focused batch of the soft-minimal / Linear-like remodel tracked in #139.

## Why

The brand previously rendered as a ghost `Button` in three spots (desktop nav, mobile sheet header, loading state) — it read as a clickable control with button padding/hover-fill and carried no identity.

## Details

- **New leaf component** `components/navbar/wordmark.tsx` — pure presentational (no router/db coupling); the navbar supplies the surrounding `<Link>`.
- All glyph colors use **design tokens** (`--primary`, `--muted-foreground`, `--foreground`, `--background`), so it adapts to dark mode automatically. Indigo is the single accent — no red→green likelihood gradient — to stay calm/minimal.
- Wired into all **three** brand sites in `components/navbar/navbar.tsx`; each `<Link>` now carries the hover (`hover:bg-muted/50`) and `focus-visible` ring chrome the Button used to provide, plus `aria-label="Forecasting home"`.
- **Storybook**: adds `components/navbar/wordmark.stories.tsx` (`Navbar/Wordmark`, autodocs) with `Default` + `OnMutedSurface` stories.

## Preview

The mark (light mode):

```
( ◞ )  Forecasting
```

…rendered: a dome gauge band in muted gray, an indigo needle pointing up-and-right, a hub dot, then the wordmark.

## Verification

- `npm run lint` — clean for the changed files
- `npm run build` — passes (TypeScript + Next build)
- `npm run build-storybook` — passes
- Visually confirmed the glyph (arc dome orientation, needle, hub, token colors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)