### PR TITLE
Soft-minimal remodel: competition score-breakdown & forecast-stats

### DIFF
--- a/app/competitions/[competitionId]/forecast-stats/cards/bold-takes-card/bold-takes-card.tsx
+++ b/app/competitions/[competitionId]/forecast-stats/cards/bold-takes-card/bold-takes-card.tsx
@@ -5,9 +5,9 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { getForecasts } from "@/lib/db_actions";
 import { VForecast } from "@/types/db_types";
+import BoldTakesContent, { BoldTake } from "./bold-takes-content";
 
 export default async function BoldTakesCard({
   competitionId,
@@ -19,7 +19,16 @@ export default async function BoldTakesCard({
     throw new Error(forecastsResult.error);
   }
   const forecasts = forecastsResult.data;
-  const boldestForecasts = getForecastsFurthestFromMean(forecasts);
+  const takes: BoldTake[] = getForecastsFurthestFromMean(forecasts).map(
+    ({ forecast, meanForecast, differenceFromMean }) => ({
+      forecastId: forecast.forecast_id,
+      propText: forecast.prop_text,
+      userName: forecast.user_name,
+      userForecast: forecast.forecast,
+      meanForecast,
+      differenceFromMean,
+    }),
+  );
   return (
     <Card className="w-80 h-96">
       <CardHeader className="pb-4">
@@ -27,40 +36,7 @@ export default async function BoldTakesCard({
         <CardDescription>Straying from the pack.</CardDescription>
       </CardHeader>
       <CardContent className="max-h-full">
-        <ScrollArea className="h-64" type="auto">
-          <div className="flex flex-col gap-y-4 h-fit">
-            {boldestForecasts.map(
-              ({ forecast, meanForecast, differenceFromMean }) => (
-                <div
-                  key={forecast.forecast_id}
-                  className="flex flex-col justify-start items-center w-full text-xs"
-                >
-                  <span className="w-full">{forecast.prop_text}</span>
-                  <div className="w-full grid grid-cols-[1fr_1fr_1fr] mt-1 text-right">
-                    <div className="flex flex-col justify-start items-end gap-0.5">
-                      <span className="text-muted-foreground">
-                        {forecast.user_name}
-                      </span>
-                      <span className="text-sm">
-                        {forecast.forecast.toFixed(2)}
-                      </span>
-                    </div>
-                    <div className="flex flex-col justify-start items-end gap-0.5">
-                      <span className="text-muted-foreground">Others</span>
-                      <span className="text-sm">{meanForecast.toFixed(2)}</span>
-                    </div>
-                    <div className="flex flex-col justify-start items-end gap-0.5">
-                      <span className="text-muted-foreground">Difference</span>
-                      <span className="text-sm">
-                        {Math.abs(differenceFromMean).toFixed(2)}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              ),
-            )}
-          </div>
-        </ScrollArea>
+        <BoldTakesContent takes={takes} />
       </CardContent>
     </Card>
   );

--- a/app/competitions/[competitionId]/forecast-stats/cards/bold-takes-card/bold-takes-content.stories.tsx
+++ b/app/competitions/[competitionId]/forecast-stats/cards/bold-takes-card/bold-takes-content.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import BoldTakesContent from "./bold-takes-content";
+
+// Renders inside the same flat card chrome as the real Stats page.
+const CardFrame = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex h-96 w-80 flex-col gap-4 rounded-lg border bg-card p-6">
+    <div>
+      <div className="font-semibold">Boldest Takes</div>
+      <div className="text-sm text-muted-foreground">Straying from the pack.</div>
+    </div>
+    {children}
+  </div>
+);
+
+const meta = {
+  title: "Competition/BoldTakesCard",
+  component: BoldTakesContent,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <CardFrame>
+        <Story />
+      </CardFrame>
+    ),
+  ],
+  argTypes: {
+    takes: { control: false },
+  },
+  args: {
+    takes: [
+      {
+        forecastId: 1,
+        propText: "Will headline inflation fall below 3% by year-end?",
+        userName: "Avery Chen",
+        userForecast: 0.85,
+        meanForecast: 0.32,
+        differenceFromMean: 0.53,
+      },
+      {
+        forecastId: 2,
+        propText: "Will the home team make the playoffs?",
+        userName: "Jordan Blake",
+        userForecast: 0.1,
+        meanForecast: 0.58,
+        differenceFromMean: 0.48,
+      },
+      {
+        forecastId: 3,
+        propText: "Will a third-party candidate exceed 5% of the vote?",
+        userName: "Sam Rivera",
+        userForecast: 0.6,
+        meanForecast: 0.18,
+        differenceFromMean: 0.42,
+      },
+      {
+        forecastId: 4,
+        propText: "Will the central bank cut rates at its next meeting?",
+        userName: "Taylor Okafor",
+        userForecast: 0.7,
+        meanForecast: 0.4,
+        differenceFromMean: 0.3,
+      },
+    ],
+  },
+} satisfies Meta<typeof BoldTakesContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// The biggest divergences from the crowd, sorted furthest-first.
+export const Default: Story = {};

--- a/app/competitions/[competitionId]/forecast-stats/cards/bold-takes-card/bold-takes-content.tsx
+++ b/app/competitions/[competitionId]/forecast-stats/cards/bold-takes-card/bold-takes-content.tsx
@@ -1,0 +1,48 @@
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+export interface BoldTake {
+  forecastId: number;
+  propText: string;
+  userName: string;
+  userForecast: number;
+  meanForecast: number;
+  differenceFromMean: number;
+}
+
+function ValueCell({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="flex flex-col items-end gap-0.5">
+      <span className="truncate text-[10px] text-muted-foreground">
+        {label}
+      </span>
+      <span className="font-mono text-sm tabular-nums text-foreground">
+        {value.toFixed(2)}
+      </span>
+    </div>
+  );
+}
+
+export default function BoldTakesContent({ takes }: { takes: BoldTake[] }) {
+  return (
+    <ScrollArea className="h-64" type="auto">
+      <div className="flex h-fit flex-col divide-y">
+        {takes.map((take) => (
+          <div
+            key={take.forecastId}
+            className="flex flex-col gap-1.5 py-3 text-xs first:pt-0"
+          >
+            <span className="text-foreground">{take.propText}</span>
+            <div className="grid grid-cols-3 text-right">
+              <ValueCell label={take.userName} value={take.userForecast} />
+              <ValueCell label="Others" value={take.meanForecast} />
+              <ValueCell
+                label="Difference"
+                value={Math.abs(take.differenceFromMean)}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/app/competitions/[competitionId]/forecast-stats/cards/certainty-card/certainty-content.stories.tsx
+++ b/app/competitions/[competitionId]/forecast-stats/cards/certainty-card/certainty-content.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import CertaintyContent from "./certainty-content";
+
+// Renders inside the same flat card chrome as the real Stats page.
+const CardFrame = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex h-96 w-80 flex-col gap-4 rounded-lg border bg-card p-6">
+    <div>
+      <div className="font-semibold">Average Certainty</div>
+      <div className="text-sm text-muted-foreground">Who&apos;s confident?</div>
+    </div>
+    {children}
+  </div>
+);
+
+const meta = {
+  title: "Competition/CertaintyCard",
+  component: CertaintyContent,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <CardFrame>
+        <Story />
+      </CardFrame>
+    ),
+  ],
+  argTypes: {
+    certainties: { control: false },
+  },
+  args: {
+    certainties: [
+      { userId: 1, userName: "Avery Chen", avgCertainty: 0.412 },
+      { userId: 2, userName: "Jordan Blake", avgCertainty: 0.357 },
+      { userId: 3, userName: "Sam Rivera", avgCertainty: 0.298 },
+      { userId: 4, userName: "Taylor Okafor", avgCertainty: 0.241 },
+      { userId: 5, userName: "Morgan Diaz", avgCertainty: 0.19 },
+      { userId: 6, userName: "Priya Nair", avgCertainty: 0.142 },
+    ],
+  },
+} satisfies Meta<typeof CertaintyContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Most-certain first (the default). Toggle the header button to reverse.
+export const Default: Story = {};

--- a/app/competitions/[competitionId]/forecast-stats/cards/certainty-card/certainty-content.tsx
+++ b/app/competitions/[competitionId]/forecast-stats/cards/certainty-card/certainty-content.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { ArrowUpDown } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -18,45 +17,45 @@ export default function CertaintyContent({
   certainties: AvgCertaintyForUser[];
 }) {
   const [reversed, setReversed] = useState(false);
-  // Sort by most certain to least certain.
-  if (reversed) {
-    certainties.sort((a, b) => a.avgCertainty - b.avgCertainty);
-  } else {
-    certainties.sort((a, b) => b.avgCertainty - a.avgCertainty);
-  }
+  // Sort a copy (most-certain first by default) so we don't mutate props.
+  const sorted = [...certainties].sort((a, b) =>
+    reversed
+      ? a.avgCertainty - b.avgCertainty
+      : b.avgCertainty - a.avgCertainty,
+  );
   return (
     <>
-      <div className="flex justify-end">
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+          Forecaster
+        </span>
         <Button
           size="sm"
           variant="ghost"
           onClick={() => setReversed(!reversed)}
-          className="gap-x-1.5"
+          className="h-7 gap-x-1.5 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground"
         >
-          {reversed ? "Least" : "Most"} certain <ArrowUpDown size={16} />
+          {reversed ? "Least" : "Most"} certain <ArrowUpDown size={14} />
         </Button>
       </div>
       <ScrollArea className="h-[13rem] px-1" type="auto">
-        <Table className="mt-1">
-          <TableBody>
-            {certainties.map(({ userId, userName, avgCertainty }) => (
-              <TableRow key={userId} className="odd:bg-background">
-                <TableCell className="text-muted-foreground text-xs">
-                  {userName}
-                </TableCell>
-                <TableCell className="text-right text-xs">
-                  {avgCertainty.toFixed(3)}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+        <div className="divide-y">
+          {sorted.map(({ userId, userName, avgCertainty }) => (
+            <div
+              key={userId}
+              className="flex items-center justify-between gap-3 py-1.5 text-sm"
+            >
+              <span className="truncate text-muted-foreground">{userName}</span>
+              <span className="font-mono tabular-nums text-foreground">
+                {avgCertainty.toFixed(3)}
+              </span>
+            </div>
+          ))}
+        </div>
       </ScrollArea>
-      <div className="w-full flex justify-center mt-2">
-        <p className="text-muted-foreground text-sm text-center">
-          Certainty is computed as the distance from 0.5
-        </p>
-      </div>
+      <p className="mt-2 text-center text-xs text-muted-foreground">
+        Certainty is the average distance from 0.5.
+      </p>
     </>
   );
 }

--- a/app/competitions/[competitionId]/forecast-stats/cards/prop-consensus-card/prop-consensus-content.tsx
+++ b/app/competitions/[competitionId]/forecast-stats/cards/prop-consensus-card/prop-consensus-content.tsx
@@ -90,23 +90,23 @@ function AllPropsConsensusChart({
         <Tooltip content={<CustomTooltip />} />
         <Scatter
           dataKey="mean"
-          shape={<RenderDot radius={5} fill="hsl(var(--primary))" />}
+          shape={<RenderDot radius={5} fill="var(--primary)" />}
         />
         <Scatter
           dataKey="p25"
-          shape={<RenderDot radius={3} fill="hsl(var(--foreground))" />}
+          shape={<RenderDot radius={3} fill="var(--foreground)" />}
         />
         <Scatter
           dataKey="p75"
-          shape={<RenderDot radius={3} fill="hsl(var(--foreground))" />}
+          shape={<RenderDot radius={3} fill="var(--foreground)" />}
         />
         <Scatter
           dataKey="min"
-          shape={<RenderDot radius={2} fill="hsl(var(--secondary))" />}
+          shape={<RenderDot radius={2} fill="var(--muted-foreground)" />}
         />
         <Scatter
           dataKey="max"
-          shape={<RenderDot radius={2} fill="hsl(var(--secondary))" />}
+          shape={<RenderDot radius={2} fill="var(--muted-foreground)" />}
         />
       </ComposedChart>
     </ChartContainer>
@@ -142,19 +142,29 @@ const CustomTooltip = ({
   if (active && payload && payload.length) {
     const stats = payload[0].payload;
     return (
-      <div className="grid min-w-32 items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
+      <div className="grid min-w-32 items-start gap-1.5 rounded-lg border bg-popover px-2.5 py-1.5 text-xs text-popover-foreground shadow-xl">
         <span className="font-semibold">{payload[0].payload.prop_text}</span>
-        <div className="grid grid-cols-2 w-full">
+        <div className="grid w-full grid-cols-2 gap-x-3">
           <p className="text-muted-foreground">Mean</p>
-          <p>{stats.mean.toFixed(2)}</p>
+          <p className="text-right font-mono tabular-nums">
+            {stats.mean.toFixed(2)}
+          </p>
           <p className="text-muted-foreground">P25</p>
-          <p>{stats.p25.toFixed(2)}</p>
+          <p className="text-right font-mono tabular-nums">
+            {stats.p25.toFixed(2)}
+          </p>
           <p className="text-muted-foreground">P75</p>
-          <p>{stats.p75.toFixed(2)}</p>
+          <p className="text-right font-mono tabular-nums">
+            {stats.p75.toFixed(2)}
+          </p>
           <p className="text-muted-foreground">Min</p>
-          <p>{stats.min.toFixed(2)}</p>
+          <p className="text-right font-mono tabular-nums">
+            {stats.min.toFixed(2)}
+          </p>
           <p className="text-muted-foreground">Max</p>
-          <p>{stats.max.toFixed(2)}</p>
+          <p className="text-right font-mono tabular-nums">
+            {stats.max.toFixed(2)}
+          </p>
         </div>
       </div>
     );

--- a/app/competitions/[competitionId]/forecast-stats/page.tsx
+++ b/app/competitions/[competitionId]/forecast-stats/page.tsx
@@ -9,7 +9,14 @@ import {
 import ErrorPage from "@/components/pages/error-page";
 import { getCompetitionById } from "@/lib/db_actions";
 import { InaccessiblePage } from "@/components/inaccessible-page";
-import PageHeading from "@/components/page-heading";
+import { Container } from "@/components/ui/container";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
 import { getCompetitionStatus } from "@/lib/competition-status";
 
 export default async function Page({
@@ -41,41 +48,65 @@ export default async function Page({
   }
 
   return (
-    <main className="flex flex-col justify-start items-start gap-4 py-4 px-8 lg:py-8 lg:px-24 w-full max-w-6xl mx-auto">
-      <PageHeading
-        title={`${competition.name} - Stats`}
-        breadcrumbs={{
-          Competitions: "/competitions",
-          [competition.name]: `/competitions/${competition.id}`,
-        }}
-      />
-      {/* Stats Cards */}
-      <div className="flex flex-row flex-wrap justify-center items-start gap-4">
-        <Suspense
-          fallback={
-            <SkeletonCard
-              title="Consensus Forecasts"
-              className="w-full h-72 sm:h-128"
-            />
-          }
-        >
-          <PropConsensusCard competitionId={competitionId} />
-        </Suspense>
-        <Suspense
-          fallback={
-            <SkeletonCard title="Average Certainty" className="w-80 h-96" />
-          }
-        >
-          <CertaintyCard competitionId={competitionId} />
-        </Suspense>
-        <Suspense
-          fallback={
-            <SkeletonCard title="Boldest Takes" className="w-80 h-96" />
-          }
-        >
-          <BoldTakesCard competitionId={competitionId} />
-        </Suspense>
-      </div>
+    <main className="py-10 lg:py-14">
+      <Container>
+        <header className="mb-8">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink href="/competitions">
+                  Competitions
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink href={`/competitions/${competition.id}`}>
+                  {competition.name}
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+          <div className="mt-4">
+            <div className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              Forecast Stats
+            </div>
+            <h1 className="mt-1 text-2xl font-semibold tracking-tight sm:text-3xl">
+              {competition.name}
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Where the crowd agrees, diverges, and commits.
+            </p>
+          </div>
+        </header>
+
+        {/* Stats Cards */}
+        <div className="flex flex-row flex-wrap items-start justify-center gap-4">
+          <Suspense
+            fallback={
+              <SkeletonCard
+                title="Consensus Forecasts"
+                className="w-full h-72 sm:h-128"
+              />
+            }
+          >
+            <PropConsensusCard competitionId={competitionId} />
+          </Suspense>
+          <Suspense
+            fallback={
+              <SkeletonCard title="Average Certainty" className="w-80 h-96" />
+            }
+          >
+            <CertaintyCard competitionId={competitionId} />
+          </Suspense>
+          <Suspense
+            fallback={
+              <SkeletonCard title="Boldest Takes" className="w-80 h-96" />
+            }
+          >
+            <BoldTakesCard competitionId={competitionId} />
+          </Suspense>
+        </div>
+      </Container>
     </main>
   );
 }

--- a/app/competitions/[competitionId]/scores/user/[userId]/components/forecast-scores-table.fixtures.ts
+++ b/app/competitions/[competitionId]/scores/user/[userId]/components/forecast-scores-table.fixtures.ts
@@ -1,0 +1,114 @@
+import type { Category } from "@/types/db_types";
+import type { UserForecastScore, UserCategoryScore } from "@/lib/db_actions";
+
+// Shared mock data for the forecast-scores-table story. Built from a flat list
+// of forecasts, then grouped/sorted the same way the page does (worst penalty
+// first) so the story mirrors real output.
+
+const D = new Date("2026-01-01T00:00:00Z");
+
+export const categories: Category[] = [
+  { id: 1, name: "Politics", updated_at: D, created_at: D },
+  { id: 2, name: "Sports", updated_at: D, created_at: D },
+  { id: 3, name: "Economics", updated_at: D, created_at: D },
+];
+
+const forecasts: UserForecastScore[] = [
+  {
+    forecastId: 1,
+    propId: 101,
+    propText: "Will the incumbent win re-election?",
+    categoryId: 1,
+    categoryName: "Politics",
+    forecast: 0.72,
+    resolution: true,
+    score: 0.078,
+  },
+  {
+    forecastId: 2,
+    propId: 102,
+    propText: "Will a third-party candidate exceed 5% of the vote?",
+    categoryId: 1,
+    categoryName: "Politics",
+    forecast: 0.15,
+    resolution: false,
+    score: 0.022,
+  },
+  {
+    forecastId: 3,
+    propId: 201,
+    propText: "Will the home team make the playoffs?",
+    categoryId: 2,
+    categoryName: "Sports",
+    forecast: 0.6,
+    resolution: true,
+    score: 0.16,
+  },
+  {
+    forecastId: 4,
+    propId: 202,
+    propText: "Will the league MVP come from the conference leader?",
+    categoryId: 2,
+    categoryName: "Sports",
+    forecast: 0.45,
+    resolution: false,
+    score: 0.203,
+  },
+  {
+    forecastId: 5,
+    propId: 301,
+    propText: "Will headline inflation fall below 3% by year-end?",
+    categoryId: 3,
+    categoryName: "Economics",
+    forecast: 0.82,
+    resolution: false,
+    score: 0.672,
+  },
+  {
+    forecastId: 6,
+    propId: 302,
+    propText: "Will unemployment stay under 5% all year?",
+    categoryId: 3,
+    categoryName: "Economics",
+    forecast: 0.9,
+    resolution: true,
+    score: 0.01,
+  },
+  {
+    forecastId: 7,
+    propId: 401,
+    propText: "Will the central bank cut rates at its next meeting?",
+    categoryId: null,
+    categoryName: null,
+    forecast: 0.35,
+    resolution: null,
+    score: null,
+  },
+];
+
+export const sortedForecasts: UserForecastScore[] = [...forecasts].sort(
+  (a, b) => (b.score ?? 0) - (a.score ?? 0),
+);
+
+export const sortedCategoryScores: UserCategoryScore[] = [
+  { userId: 1, userName: "Avery Chen", categoryId: 3, score: 0.341 },
+  { userId: 1, userName: "Avery Chen", categoryId: 2, score: 0.182 },
+  { userId: 1, userName: "Avery Chen", categoryId: 1, score: 0.05 },
+];
+
+export const sortedCategoryEntries: Array<
+  [number | "uncategorized", UserForecastScore[]]
+> = [
+  ...sortedCategoryScores.map(
+    (cs): [number | "uncategorized", UserForecastScore[]] => [
+      cs.categoryId,
+      forecasts
+        .filter((f) => f.categoryId === cs.categoryId)
+        .sort((a, b) => (b.score ?? 0) - (a.score ?? 0)),
+    ],
+  ),
+  [
+    "uncategorized",
+    forecasts.filter((f) => f.categoryId === null),
+  ] as [number | "uncategorized", UserForecastScore[]],
+];

--- a/app/competitions/[competitionId]/scores/user/[userId]/components/forecast-scores-table.stories.tsx
+++ b/app/competitions/[competitionId]/scores/user/[userId]/components/forecast-scores-table.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ForecastScoresTable } from "./forecast-scores-table";
+import {
+  categories,
+  sortedCategoryEntries,
+  sortedCategoryScores,
+  sortedForecasts,
+} from "./forecast-scores-table.fixtures";
+
+const meta = {
+  title: "Competition/ForecastScoresTable",
+  component: ForecastScoresTable,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-3xl">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    sortedCategoryEntries: { control: false },
+    sortedCategoryScores: { control: false },
+    sortedForecasts: { control: false },
+    categories: { control: false },
+  },
+  args: {
+    sortedCategoryEntries,
+    sortedCategoryScores,
+    sortedForecasts,
+    categories,
+  },
+} satisfies Meta<typeof ForecastScoresTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Grouped by category (the default). Each category band shows its aggregate
+// penalty; rows are sorted worst-penalty-first. Flip the switch to see the
+// flat, penalty-ranked view.
+export const Default: Story = {};

--- a/app/competitions/[competitionId]/scores/user/[userId]/components/forecast-scores-table.tsx
+++ b/app/competitions/[competitionId]/scores/user/[userId]/components/forecast-scores-table.tsx
@@ -3,11 +3,10 @@
 import { useState } from "react";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { TableByCategory } from "./table-by-category";
 import { TableByPenalty } from "./table-by-penalty";
-import { Category } from "@/types/db_types";
-import { UserForecastScore, UserCategoryScore } from "@/lib/db_actions";
+import type { Category } from "@/types/db_types";
+import type { UserForecastScore, UserCategoryScore } from "@/lib/db_actions";
 
 interface ForecastScoresTableProps {
   sortedCategoryEntries: Array<[number | "uncategorized", UserForecastScore[]]>;
@@ -25,12 +24,17 @@ export function ForecastScoresTable({
   const [byCategory, setByCategory] = useState(true);
 
   return (
-    <>
-      <CardHeader className="flex flex-row items-center justify-between">
-        <CardTitle>Forecast Penalties</CardTitle>
-        <div className="flex items-center gap-3">
-          <Label htmlFor="by-category" className="cursor-pointer">
-            By Category
+    <section className="w-full overflow-hidden rounded-lg border bg-card">
+      <div className="flex items-center justify-between gap-3 border-b px-4 py-3 sm:px-5">
+        <span className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+          Forecast Penalties
+        </span>
+        <div className="flex items-center gap-2.5">
+          <Label
+            htmlFor="by-category"
+            className="cursor-pointer text-xs text-muted-foreground"
+          >
+            By category
           </Label>
           <Switch
             id="by-category"
@@ -38,20 +42,18 @@ export function ForecastScoresTable({
             onCheckedChange={setByCategory}
           />
         </div>
-      </CardHeader>
-      <CardContent>
-        <div className="overflow-x-auto">
-          {byCategory ? (
-            <TableByCategory
-              sortedCategoryEntries={sortedCategoryEntries}
-              sortedCategoryScores={sortedCategoryScores}
-              categories={categories}
-            />
-          ) : (
-            <TableByPenalty sortedForecasts={sortedForecasts} />
-          )}
-        </div>
-      </CardContent>
-    </>
+      </div>
+      <div className="overflow-x-auto px-2 py-1 sm:px-3">
+        {byCategory ? (
+          <TableByCategory
+            sortedCategoryEntries={sortedCategoryEntries}
+            sortedCategoryScores={sortedCategoryScores}
+            categories={categories}
+          />
+        ) : (
+          <TableByPenalty sortedForecasts={sortedForecasts} />
+        )}
+      </div>
+    </section>
   );
 }

--- a/app/competitions/[competitionId]/scores/user/[userId]/components/score-table-parts.tsx
+++ b/app/competitions/[competitionId]/scores/user/[userId]/components/score-table-parts.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+import {
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { UserForecastScore } from "@/lib/db_actions";
+
+const kickerHeadClass =
+  "h-9 font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground";
+
+/** Shared column header for the forecast-score tables (mono kicker labels). */
+export function ScoreTableHead() {
+  return (
+    <TableHeader>
+      <TableRow className="hover:bg-transparent">
+        <TableHead className={kickerHeadClass}>Proposition</TableHead>
+        <TableHead className={`${kickerHeadClass} text-right`}>
+          Forecast
+        </TableHead>
+        <TableHead className={`${kickerHeadClass} text-right`}>
+          Resolution
+        </TableHead>
+        <TableHead className={`${kickerHeadClass} text-right`}>
+          Penalty
+        </TableHead>
+      </TableRow>
+    </TableHeader>
+  );
+}
+
+function ResolutionLabel({ resolution }: { resolution: boolean | null }) {
+  if (resolution === null) {
+    return <span className="text-muted-foreground">—</span>;
+  }
+  return (
+    <span className="font-mono text-foreground">
+      {resolution ? "Yes" : "No"}
+    </span>
+  );
+}
+
+/** A single forecast row, shared by the by-category and by-penalty tables. */
+export function ForecastScoreRow({
+  forecast,
+}: {
+  forecast: UserForecastScore;
+}) {
+  return (
+    <TableRow>
+      <TableCell className="max-w-md">
+        <div className="flex items-center gap-2">
+          <div className="flex-1 truncate text-foreground">
+            {forecast.propText}
+          </div>
+          <Link
+            href={`/props/${forecast.propId}`}
+            className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ExternalLink className="h-3 w-3" />
+          </Link>
+        </div>
+      </TableCell>
+      <TableCell className="text-right font-mono tabular-nums text-foreground">
+        {(forecast.forecast * 100).toFixed(1)}%
+      </TableCell>
+      <TableCell className="text-right text-sm">
+        <ResolutionLabel resolution={forecast.resolution} />
+      </TableCell>
+      <TableCell className="text-right font-mono font-medium tabular-nums text-foreground">
+        {forecast.score !== null ? forecast.score.toFixed(3) : "—"}
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/app/competitions/[competitionId]/scores/user/[userId]/components/table-by-category.tsx
+++ b/app/competitions/[competitionId]/scores/user/[userId]/components/table-by-category.tsx
@@ -1,15 +1,13 @@
-import Link from "next/link";
-import { ExternalLink } from "lucide-react";
+import { Fragment } from "react";
 import {
   Table,
   TableBody,
   TableCell,
-  TableHead,
-  TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Category } from "@/types/db_types";
-import { UserForecastScore, UserCategoryScore } from "@/lib/db_actions";
+import type { Category } from "@/types/db_types";
+import type { UserForecastScore, UserCategoryScore } from "@/lib/db_actions";
+import { ForecastScoreRow, ScoreTableHead } from "./score-table-parts";
 
 interface TableByCategoryProps {
   sortedCategoryEntries: Array<[number | "uncategorized", UserForecastScore[]]>;
@@ -24,14 +22,7 @@ export function TableByCategory({
 }: TableByCategoryProps) {
   return (
     <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Proposition</TableHead>
-          <TableHead className="text-right">Forecast</TableHead>
-          <TableHead className="text-right">Resolution</TableHead>
-          <TableHead className="text-right">Penalty</TableHead>
-        </TableRow>
-      </TableHeader>
+      <ScoreTableHead />
       <TableBody>
         {sortedCategoryEntries.map(([categoryKey, forecasts]) => {
           const categoryId =
@@ -49,49 +40,27 @@ export function TableByCategory({
           );
 
           return (
-            <>
-              {/* Category Header Row */}
-              <TableRow key={`category-${categoryKey}`}>
+            <Fragment key={`category-${categoryKey}`}>
+              {/* Category header row: mono kicker label + aggregate penalty */}
+              <TableRow className="border-y bg-muted/40 hover:bg-muted/40">
                 <TableCell
                   colSpan={3}
-                  className="font-semibold text-lg bg-muted/50 py-3"
+                  className="py-2 font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground"
                 >
                   {category?.name || "Uncategorized"}
                 </TableCell>
-                <TableCell className="text-right font-semibold text-lg bg-muted/50 py-3">
-                  {categoryScore ? categoryScore.score.toFixed(3) : "-"}
+                <TableCell className="py-2 text-right font-mono font-medium tabular-nums text-foreground">
+                  {categoryScore ? categoryScore.score.toFixed(3) : "—"}
                 </TableCell>
               </TableRow>
-              {/* Forecast Rows */}
+              {/* Forecast rows */}
               {forecasts.map((forecast) => (
-                <TableRow key={forecast.forecastId}>
-                  <TableCell className="max-w-md">
-                    <div className="flex items-center gap-2">
-                      <div className="truncate flex-1">{forecast.propText}</div>
-                      <Link
-                        href={`/props/${forecast.propId}`}
-                        className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        <ExternalLink className="h-3 w-3" />
-                      </Link>
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-right">
-                    {(forecast.forecast * 100).toFixed(1)}%
-                  </TableCell>
-                  <TableCell className="text-right">
-                    {forecast.resolution === null
-                      ? "-"
-                      : forecast.resolution
-                        ? "Yes"
-                        : "No"}
-                  </TableCell>
-                  <TableCell className="text-right font-medium">
-                    {forecast.score !== null ? forecast.score.toFixed(3) : "-"}
-                  </TableCell>
-                </TableRow>
+                <ForecastScoreRow
+                  key={forecast.forecastId}
+                  forecast={forecast}
+                />
               ))}
-            </>
+            </Fragment>
           );
         })}
       </TableBody>

--- a/app/competitions/[competitionId]/scores/user/[userId]/components/table-by-penalty.tsx
+++ b/app/competitions/[competitionId]/scores/user/[userId]/components/table-by-penalty.tsx
@@ -1,14 +1,6 @@
-import Link from "next/link";
-import { ExternalLink } from "lucide-react";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { UserForecastScore } from "@/lib/db_actions";
+import { Table, TableBody } from "@/components/ui/table";
+import type { UserForecastScore } from "@/lib/db_actions";
+import { ForecastScoreRow, ScoreTableHead } from "./score-table-parts";
 
 interface TableByPenaltyProps {
   sortedForecasts: UserForecastScore[];
@@ -17,42 +9,10 @@ interface TableByPenaltyProps {
 export function TableByPenalty({ sortedForecasts }: TableByPenaltyProps) {
   return (
     <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>Proposition</TableHead>
-          <TableHead className="text-right">Forecast</TableHead>
-          <TableHead className="text-right">Resolution</TableHead>
-          <TableHead className="text-right">Penalty</TableHead>
-        </TableRow>
-      </TableHeader>
+      <ScoreTableHead />
       <TableBody>
         {sortedForecasts.map((forecast) => (
-          <TableRow key={forecast.forecastId}>
-            <TableCell className="max-w-md">
-              <div className="flex items-center gap-2">
-                <div className="truncate flex-1">{forecast.propText}</div>
-                <Link
-                  href={`/props/${forecast.propId}`}
-                  className="shrink-0 text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  <ExternalLink className="h-3 w-3" />
-                </Link>
-              </div>
-            </TableCell>
-            <TableCell className="text-right">
-              {(forecast.forecast * 100).toFixed(1)}%
-            </TableCell>
-            <TableCell className="text-right">
-              {forecast.resolution === null
-                ? "-"
-                : forecast.resolution
-                  ? "Yes"
-                  : "No"}
-            </TableCell>
-            <TableCell className="text-right font-medium">
-              {forecast.score !== null ? forecast.score.toFixed(3) : "-"}
-            </TableCell>
-          </TableRow>
+          <ForecastScoreRow key={forecast.forecastId} forecast={forecast} />
         ))}
       </TableBody>
     </Table>

--- a/app/competitions/[competitionId]/scores/user/[userId]/page.tsx
+++ b/app/competitions/[competitionId]/scores/user/[userId]/page.tsx
@@ -3,10 +3,15 @@ import {
   getUserScoreBreakdown,
   getCategories,
 } from "@/lib/db_actions";
-import PageHeading from "@/components/page-heading";
 import ErrorPage from "@/components/pages/error-page";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Medal } from "lucide-react";
+import { Container } from "@/components/ui/container";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
 import { ForecastScoresTable } from "./components/forecast-scores-table";
 
 export default async function UserScorePage({
@@ -109,62 +114,79 @@ export default async function UserScorePage({
   });
 
   return (
-    <main className="flex flex-col items-start py-4 px-8 lg:py-8 lg:px-24 w-full max-w-4xl mx-auto">
-      <PageHeading
-        title={`${scoreBreakdown.userName} - Score Breakdown`}
-        breadcrumbs={{
-          Competitions: "/competitions",
-          [competition.name]: `/competitions/${competition.id}`,
-          Scores: `/competitions/${competition.id}?tab=leaderboard`,
-        }}
-      />
-
-      <div className="flex flex-col gap-6 w-full">
-        {/* Overall Score Summary */}
-        <Card className="w-full">
-          <CardHeader className="pb-3">
-            <CardTitle className="flex items-center gap-2 text-base">
-              <Medal className="h-4 w-4" />
-              Overall Score
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="pt-0">
-            <div className="flex flex-col gap-2">
-              <div className="text-5xl font-bold tracking-tight">
-                {scoreBreakdown.overallScore.toFixed(3)}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                Average Brier Score across all categories
-              </div>
+    <main className="py-10 lg:py-14">
+      <Container>
+        <header className="mb-8">
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbLink href="/competitions">
+                  Competitions
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink href={`/competitions/${competition.id}`}>
+                  {competition.name}
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                <BreadcrumbLink
+                  href={`/competitions/${competition.id}?tab=leaderboard`}
+                >
+                  Scores
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+          <div className="mt-4">
+            <div className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              Score Breakdown
             </div>
-          </CardContent>
-        </Card>
+            <h1 className="mt-1 text-2xl font-semibold tracking-tight sm:text-3xl">
+              {scoreBreakdown.userName}
+            </h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {competition.name}
+            </p>
+          </div>
+        </header>
 
-        {/* Forecast Penalties */}
-        {scoreBreakdown.forecastScores.length > 0 && (
-          <Card className="w-full">
+        <div className="flex flex-col gap-6">
+          {/* Overall score — flat instrument panel */}
+          <div className="rounded-lg border bg-card p-5 sm:p-6">
+            <div className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+              Overall Brier Score
+            </div>
+            <div className="mt-2 font-mono text-5xl font-semibold tabular-nums tracking-tight text-foreground">
+              {scoreBreakdown.overallScore.toFixed(3)}
+            </div>
+            <div className="mt-1.5 text-sm text-muted-foreground">
+              Average across all categories · lower is better
+            </div>
+          </div>
+
+          {/* Forecast Penalties */}
+          {scoreBreakdown.forecastScores.length > 0 ? (
             <ForecastScoresTable
               sortedCategoryEntries={sortedCategoryEntries}
               sortedCategoryScores={sortedCategoryScores}
               sortedForecasts={sortedForecasts}
               categories={categories}
             />
-          </Card>
-        )}
-
-        {scoreBreakdown.forecastScores.length === 0 && (
-          <Card className="w-full">
-            <CardContent className="py-8">
-              <div className="text-center text-muted-foreground">
-                <p className="text-lg">No resolved forecasts found</p>
-                <p className="text-sm mt-1">
-                  Scores will appear once propositions are resolved
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-        )}
-      </div>
+          ) : (
+            <div className="rounded-lg border bg-card p-8 text-center">
+              <p className="text-muted-foreground">
+                No resolved forecasts found
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Scores will appear once propositions are resolved
+              </p>
+            </div>
+          )}
+        </div>
+      </Container>
     </main>
   );
 }


### PR DESCRIPTION
Continues the soft-minimal / Linear-like UI remodel (#139), tackling the cohesive **"Competition sub-pages"** group: the per-user **score breakdown** and the **forecast-stats** cards. Both are data-instrument surfaces, so they get the same treatment — flat surfaces, mono tabular numerics, mono-kicker headers, and `Container`-based left-aligned page headers replacing the centered `PageHeading`.

### Per-user score breakdown — `scores/user/[userId]`
- Replaced the centered `PageHeading` + `Medal` `Card` with a `Container` layout and a left-aligned header (breadcrumb → mono kicker → title/subtitle).
- Overall score is now a flat instrument panel with a `font-mono tabular-nums` readout.
- Restyled the by-category / by-penalty tables: mono uppercase kicker column heads, mono tabular numerics, flat category bands, hairline borders (no shadow Cards).
- Extracted a shared `ScoreTableHead` / `ForecastScoreRow` (`score-table-parts.tsx`) to de-duplicate the two tables.

### Forecast-stats cards — `forecast-stats`
- Same `Container` + left-aligned header treatment.
- Flat instrument cards with mono tabular numerics and calmer chrome.
- **Bug fix:** the consensus chart's dots used `hsl(var(--primary))` etc., but the design tokens are now `oklch(...)`, so `hsl(oklch(...))` was invalid and the dots fell back to default black. Switched to `var(--token)` so the mean / quartile / min-max encoding is meaningful again (and bumped the faint `--secondary` min/max dots to `--muted-foreground` so they're actually visible).
- Extracted a presentational `BoldTakesContent` (mirroring the existing `CertaintyCard` / `CertaintyContent` split) and stopped `CertaintyContent` from mutating its props while sorting.

### Storybook
Added stories for the notable presentational pieces:
- `Competition/ForecastScoresTable` (toggle between category/penalty views)
- `Competition/CertaintyCard` (content, in card chrome)
- `Competition/BoldTakesCard` (content, in card chrome)

### Checklist progress (#139)
- [x] Per-user score breakdown
- [x] Forecast-stats cards

### Verification
- `npm run lint` — 0 errors (pre-existing warnings only, in untouched files)
- `npm run test` — 203 passed / 9 skipped
- `npm run build-storybook` — success
- `npx tsc --noEmit` — clean

https://claude.ai/code/session_0198QsRCdYoTJvVjDzc2D8fT

---
_Generated by [Claude Code](https://claude.ai/code/session_0198QsRCdYoTJvVjDzc2D8fT)_