### PR TITLE
Soft-minimal remodel: login + forms (Forms & entry)

### DIFF
--- a/app/competitions/[competitionId]/props/new/new-prop-form.tsx
+++ b/app/competitions/[competitionId]/props/new/new-prop-form.tsx
@@ -5,17 +5,7 @@ import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import {
-  AlertTriangle,
-  FileText,
-  Hash,
-  Tag,
-  CalendarClock,
-  Calendar,
-  Eye,
-  EyeOff,
-  Lightbulb,
-} from "lucide-react";
+import { AlertTriangle, Eye, EyeOff } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -152,10 +142,7 @@ export function NewPropForm({
             name="text"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-sm font-medium flex items-center gap-2">
-                  <FileText className="h-4 w-4" />
-                  Proposition
-                </FormLabel>
+                <FormLabel className="text-sm font-medium">Proposition</FormLabel>
                 <FormControl>
                   <Textarea
                     {...field}
@@ -183,10 +170,9 @@ export function NewPropForm({
             name="notes"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-sm font-medium flex items-center gap-2">
-                  <Hash className="h-4 w-4" />
+                <FormLabel className="flex items-center gap-2 text-sm font-medium">
                   Notes
-                  <span className="text-xs text-muted-foreground font-normal">
+                  <span className="text-xs font-normal text-muted-foreground">
                     (Optional)
                   </span>
                 </FormLabel>
@@ -218,10 +204,9 @@ export function NewPropForm({
             name="category_id"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-sm font-medium flex items-center gap-2">
-                  <Tag className="h-4 w-4" />
+                <FormLabel className="flex items-center gap-2 text-sm font-medium">
                   Category
-                  <span className="text-xs text-muted-foreground font-normal">
+                  <span className="text-xs font-normal text-muted-foreground">
                     (Optional)
                   </span>
                 </FormLabel>
@@ -258,8 +243,7 @@ export function NewPropForm({
               name="forecasts_due_date"
               render={({ field }) => (
                 <FormItem className="flex flex-col">
-                  <FormLabel className="text-sm font-medium flex items-center gap-2">
-                    <CalendarClock className="h-4 w-4" />
+                  <FormLabel className="text-sm font-medium">
                     Forecast Deadline
                   </FormLabel>
                   <FormControl>
@@ -284,8 +268,7 @@ export function NewPropForm({
               name="resolution_due_date"
               render={({ field }) => (
                 <FormItem className="flex flex-col">
-                  <FormLabel className="text-sm font-medium flex items-center gap-2">
-                    <Calendar className="h-4 w-4" />
+                  <FormLabel className="text-sm font-medium">
                     Resolution Deadline
                   </FormLabel>
                   <FormControl>
@@ -359,20 +342,17 @@ export function NewPropForm({
 
           {/* Tips */}
           <div className="rounded-lg border bg-muted/30 p-4">
-            <div className="flex items-start gap-3">
-              <Lightbulb className="h-5 w-5 text-yellow-500 mt-0.5" />
-              <div className="space-y-2 text-sm">
-                <p className="font-medium">Tips for good propositions:</p>
-                <ul className="list-disc list-inside text-muted-foreground space-y-1">
-                  <li>Frame as a clear yes/no question</li>
-                  <li>Include specific dates or metrics when possible</li>
-                  <li>Define resolution criteria in the notes</li>
-                  <li>
-                    Set forecast deadline before the event could reasonably occur
-                  </li>
-                </ul>
-              </div>
-            </div>
+            <p className="mb-2 font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+              Tips for good propositions
+            </p>
+            <ul className="list-inside list-disc space-y-1 text-sm text-muted-foreground">
+              <li>Frame as a clear yes/no question</li>
+              <li>Include specific dates or metrics when possible</li>
+              <li>Define resolution criteria in the notes</li>
+              <li>
+                Set forecast deadline before the event could reasonably occur
+              </li>
+            </ul>
           </div>
 
           {/* Error Alert */}

--- a/app/login/loading.tsx
+++ b/app/login/loading.tsx
@@ -1,17 +1,28 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
+import { Wordmark } from "@/components/navbar/wordmark";
 
 export default async function Loading() {
   return (
-    <div className="flex items-center justify-center mt-48">
-      <Card className="w-full max-w-md mx-4">
-        <CardHeader>
-          <CardTitle className="text-xl">Login</CardTitle>
-        </CardHeader>
-        <CardContent className="flex items-center justify-center h-48">
-          <Spinner className="w-24 h-24 text-muted-foreground" />
-        </CardContent>
-      </Card>
+    <div className="flex flex-col items-center justify-start px-4 pb-8 pt-16 sm:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-md">
+        <Card className="w-full">
+          <CardHeader className="gap-3">
+            <Wordmark />
+            <CardTitle className="text-xl font-semibold tracking-tight">
+              Sign in
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="flex h-32 items-center justify-center">
+            <Spinner className="h-10 w-10 text-muted-foreground" />
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/app/login/login-form-card.tsx
+++ b/app/login/login-form-card.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { AlertTriangle, Lock, LogIn } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Spinner } from "@/components/ui/spinner";
+import { Wordmark } from "@/components/navbar/wordmark";
 
 interface LoginFormCardProps {
   redirectUrl?: string;
@@ -33,61 +34,50 @@ export default function LoginFormCard({
   }
 
   return (
-    <Card className="w-full shadow-xl border-0 bg-card/50 backdrop-blur-sm">
-      <CardHeader className="space-y-4 pb-6">
-        <div className="text-center">
-          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
-            <Lock className="h-6 w-6 text-primary" />
-          </div>
-          <CardTitle className="text-2xl font-bold">Sign in</CardTitle>
-          <CardDescription className="text-muted-foreground">
+    <Card className="w-full">
+      <CardHeader className="gap-3">
+        <Wordmark />
+        <div className="space-y-1">
+          <CardTitle className="text-xl font-semibold tracking-tight">
+            Sign in
+          </CardTitle>
+          <CardDescription>
             Sign in with your identity provider account
           </CardDescription>
         </div>
       </CardHeader>
-      <CardContent className="space-y-6">
-        <div className="space-y-4">
-          <div className="rounded-lg bg-muted/50 p-4">
-            <p className="text-sm text-center">
-              You&apos;ll be redirected to sign in with your identity provider
-              account.
-            </p>
-          </div>
+      <CardContent className="space-y-4">
+        <p className="rounded-lg border bg-muted/40 p-3 text-sm text-muted-foreground">
+          You&apos;ll be redirected to sign in with your identity provider
+          account.
+        </p>
 
-          <Button
-            onClick={handleSignIn}
-            className="w-full h-11 text-base font-medium"
-            disabled={loading}
-          >
-            {loading ? (
-              <>
-                <Spinner className="mr-2 h-4 w-4" />
-                Redirecting...
-              </>
-            ) : (
-              <>
-                <LogIn className="mr-2 h-4 w-4" />
-                Sign in
-              </>
-            )}
-          </Button>
-
-          {initialError && (
-            <Alert variant="destructive">
-              <AlertTriangle className="h-4 w-4" />
-              <AlertTitle>Authentication failed</AlertTitle>
-              <AlertDescription>{initialError}</AlertDescription>
-            </Alert>
+        <Button
+          onClick={handleSignIn}
+          className="h-11 w-full font-medium"
+          disabled={loading}
+        >
+          {loading ? (
+            <>
+              <Spinner className="mr-2 h-4 w-4" />
+              Redirecting...
+            </>
+          ) : (
+            "Sign in"
           )}
-        </div>
+        </Button>
 
-        <div className="space-y-3 text-center">
-          <div className="rounded-lg bg-muted/50 p-3">
-            <p className="text-xs text-muted-foreground">
-              Don&apos;t have an account? Contact Ethan to get set up.
-            </p>
-          </div>
-        </div>
+        {initialError && (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertTitle>Authentication failed</AlertTitle>
+            <AlertDescription>{initialError}</AlertDescription>
+          </Alert>
+        )}
+
+        <p className="text-xs text-muted-foreground">
+          Don&apos;t have an account? Contact Ethan to get set up.
+        </p>
       </CardContent>
     </Card>
   );

--- a/app/props/suggest/page.tsx
+++ b/app/props/suggest/page.tsx
@@ -1,11 +1,9 @@
-import PageHeading from "@/components/page-heading";
 import { SuggestPropForm } from "./suggest-prop-form";
 
 export default async function SuggestPropPage() {
   return (
-    <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
-      <div className="w-full max-w-lg">
-        <PageHeading title="Suggest Prop" breadcrumbs={{}} className="mb-2" />
+    <main className="px-6 py-8 lg:py-12">
+      <div className="mx-auto w-full max-w-2xl">
         <SuggestPropForm />
       </div>
     </main>

--- a/app/props/suggest/suggest-prop-form.tsx
+++ b/app/props/suggest/suggest-prop-form.tsx
@@ -15,7 +15,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { AlertTriangle, FileText, Hash } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
 import { useToast } from "@/hooks/use-toast";
 
@@ -96,12 +96,12 @@ export function SuggestPropForm() {
   }
 
   return (
-    <Card className="w-full max-w-2xl mx-auto shadow-xl border-0 bg-card/50 backdrop-blur-sm">
-      <CardHeader className="text-center">
-        <CardTitle className="text-xl sm:text-2xl font-semibold">
+    <Card className="mx-auto w-full max-w-2xl">
+      <CardHeader>
+        <CardTitle className="text-xl font-semibold tracking-tight">
           Suggest a Proposition
         </CardTitle>
-        <p className="text-sm sm:text-base text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           Submit a new proposition for consideration in forecasting competitions
         </p>
       </CardHeader>
@@ -113,10 +113,9 @@ export function SuggestPropForm() {
               name="propText"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel className="text-sm sm:text-base font-medium flex items-center gap-2">
-                    <FileText className="h-4 w-4" />
+                  <FormLabel className="flex items-center gap-2 text-sm font-medium">
                     Prop Text
-                    <span className="text-xs text-muted-foreground font-normal">
+                    <span className="text-xs font-normal text-muted-foreground">
                       (Markdown supported)
                     </span>
                   </FormLabel>
@@ -124,7 +123,7 @@ export function SuggestPropForm() {
                     <Textarea
                       {...field}
                       placeholder="Enter the proposition text here. Be clear and specific about what you're asking people to forecast. Markdown formatting (links, bold, italic) is supported."
-                      className="min-h-[120px] resize-none text-sm sm:text-base"
+                      className="min-h-[120px] resize-none"
                       rows={5}
                     />
                   </FormControl>
@@ -138,10 +137,9 @@ export function SuggestPropForm() {
               name="notes"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel className="text-sm sm:text-base font-medium flex items-center gap-2">
-                    <Hash className="h-4 w-4" />
+                  <FormLabel className="flex items-center gap-2 text-sm font-medium">
                     Additional Notes (Optional)
-                    <span className="text-xs text-muted-foreground font-normal">
+                    <span className="text-xs font-normal text-muted-foreground">
                       (Markdown supported)
                     </span>
                   </FormLabel>
@@ -149,7 +147,7 @@ export function SuggestPropForm() {
                     <Textarea
                       {...field}
                       placeholder="Add any additional context, clarification, or background information that might be helpful for reviewers. Markdown formatting (links, bold, italic) is supported."
-                      className="min-h-[80px] resize-none text-sm sm:text-base"
+                      className="min-h-[80px] resize-none"
                       rows={3}
                     />
                   </FormControl>
@@ -158,21 +156,14 @@ export function SuggestPropForm() {
               )}
             />
 
-            <div className="flex flex-col sm:flex-row gap-3 pt-4">
+            <div className="flex flex-col gap-3 pt-4 sm:flex-row">
               {loading ? (
-                <Button
-                  type="submit"
-                  disabled
-                  className="flex-1 text-sm sm:text-base"
-                >
+                <Button type="submit" disabled className="h-11 flex-1 font-medium">
                   <Spinner className="mr-2 h-4 w-4" />
                   Submitting...
                 </Button>
               ) : (
-                <Button
-                  type="submit"
-                  className="flex-1 text-sm sm:text-base h-11 font-medium"
-                >
+                <Button type="submit" className="h-11 flex-1 font-medium">
                   Submit Proposition
                 </Button>
               )}

--- a/components/forms/create-edit-competition-form.tsx
+++ b/components/forms/create-edit-competition-form.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  AlertTriangle,
-  Trophy,
-  Calendar,
-  CalendarClock,
-  Lock,
-} from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
 import { createCompetition, updateCompetition } from "@/lib/db_actions";
 import { Button } from "@/components/ui/button";
@@ -123,8 +117,7 @@ export function CreateEditCompetitionForm({
           name="name"
           render={({ field }) => (
             <FormItem className="space-y-2">
-              <FormLabel className="text-sm font-medium flex items-center gap-2">
-                <Trophy className="h-4 w-4" />
+              <FormLabel className="text-sm font-medium">
                 Competition Name
               </FormLabel>
               <FormControl>
@@ -146,8 +139,7 @@ export function CreateEditCompetitionForm({
             render={({ field }) => (
               <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
                 <div className="space-y-0.5">
-                  <FormLabel className="text-sm font-medium flex items-center gap-2">
-                    <Lock className="h-4 w-4" />
+                  <FormLabel className="text-sm font-medium">
                     Private Competition
                   </FormLabel>
                   <FormDescription className="text-xs">
@@ -172,8 +164,7 @@ export function CreateEditCompetitionForm({
               name="forecasts_open_date"
               render={({ field }) => (
                 <FormItem className="flex flex-col space-y-2">
-                  <FormLabel className="text-sm font-medium flex items-center gap-2">
-                    <Calendar className="h-4 w-4" />
+                  <FormLabel className="text-sm font-medium">
                     Forecasts Open Date
                   </FormLabel>
                   <FormControl>
@@ -192,8 +183,7 @@ export function CreateEditCompetitionForm({
               name="forecasts_close_date"
               render={({ field }) => (
                 <FormItem className="flex flex-col space-y-2">
-                  <FormLabel className="text-sm font-medium flex items-center gap-2">
-                    <CalendarClock className="h-4 w-4" />
+                  <FormLabel className="text-sm font-medium">
                     Forecasts Due Date
                   </FormLabel>
                   <FormControl>
@@ -212,8 +202,7 @@ export function CreateEditCompetitionForm({
               name="end_date"
               render={({ field }) => (
                 <FormItem className="flex flex-col space-y-2">
-                  <FormLabel className="text-sm font-medium flex items-center gap-2">
-                    <Calendar className="h-4 w-4" />
+                  <FormLabel className="text-sm font-medium">
                     Competition End Date
                   </FormLabel>
                   <FormControl>

--- a/components/ui/alert.stories.tsx
+++ b/components/ui/alert.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AlertTriangle, Info } from "lucide-react";
+import { Alert, AlertTitle, AlertDescription } from "./alert";
+
+const meta = {
+  title: "UI/Alert",
+  component: Alert,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "destructive"],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[480px] max-w-full">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Alert>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Alert {...args}>
+      <Info className="h-4 w-4" />
+      <AlertTitle>Heads up</AlertTitle>
+      <AlertDescription>
+        Forecasts close automatically at the deadline.
+      </AlertDescription>
+    </Alert>
+  ),
+};
+
+// The error state shown by every form in the app on a failed submission.
+export const Destructive: Story = {
+  args: { variant: "destructive" },
+  render: (args) => (
+    <Alert {...args}>
+      <AlertTriangle className="h-4 w-4" />
+      <AlertTitle>Submission failed</AlertTitle>
+      <AlertDescription>
+        Something went wrong while saving. Please try again.
+      </AlertDescription>
+    </Alert>
+  ),
+};
+
+// Title only, no supporting copy.
+export const TitleOnly: Story = {
+  render: () => (
+    <Alert>
+      <Info className="h-4 w-4" />
+      <AlertTitle>This competition is now closed.</AlertTitle>
+    </Alert>
+  ),
+};

--- a/components/ui/textarea.stories.tsx
+++ b/components/ui/textarea.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Textarea } from "./textarea";
+import { Label } from "./label";
+
+const meta = {
+  title: "UI/Textarea",
+  component: Textarea,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    disabled: { control: "boolean" },
+    placeholder: { control: "text" },
+    rows: { control: "number" },
+  },
+  args: {
+    placeholder: "Enter text...",
+  },
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div className="w-[420px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+// The pattern used across the prop forms: a plain text label, an optional
+// inline hint, and a character counter under the field.
+export const WithLabelAndCounter: Story = {
+  render: (args) => (
+    <div className="grid w-[420px] gap-2">
+      <Label className="flex items-center gap-2 text-sm font-medium">
+        Proposition
+        <span className="text-xs font-normal text-muted-foreground">
+          (Markdown supported)
+        </span>
+      </Label>
+      <Textarea
+        {...args}
+        className="min-h-24 resize-none"
+        placeholder="e.g., Will the new product launch before March 2026?"
+        defaultValue="Will global average temperature rise by more than 1.5°C this year?"
+      />
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Write a clear yes/no question.
+        </p>
+        <span className="text-xs text-muted-foreground">62/300</span>
+      </div>
+    </div>
+  ),
+};
+
+export const States: Story = {
+  render: () => (
+    <div className="grid w-[420px] gap-4">
+      <div className="grid gap-1.5">
+        <Label>Default</Label>
+        <Textarea placeholder="Default textarea" className="resize-none" />
+      </div>
+      <div className="grid gap-1.5">
+        <Label>With value</Label>
+        <Textarea
+          defaultValue="Some forecast notes go here."
+          className="resize-none"
+        />
+      </div>
+      <div className="grid gap-1.5">
+        <Label>Disabled</Label>
+        <Textarea placeholder="Disabled textarea" disabled className="resize-none" />
+      </div>
+    </div>
+  ),
+};


### PR DESCRIPTION
Applies the soft-minimal / Linear-like design language to the **auth + form** surfaces — the *Forms & entry* group in #139 (follows #142).

## What changed

- **`login-form-card`** — flat card (drops `shadow-xl border-0 bg-card/50 backdrop-blur-sm`), left-aligned header with the gauge **`Wordmark`** instead of the centered Lock medallion, calmer info box, plain primary button.
- **`login/loading`** — mirrors the new card shell (flat, Wordmark, left "Sign in" header) and the page's positioning so the skeleton → loaded transition doesn't jump.
- **`suggest-prop-form`** — flat card, left-aligned header, de-iconed labels, consistent button height/weight. The page's now-redundant centered `PageHeading` (empty breadcrumbs) is removed so the card header is the sole title.
- **`new-prop-form`** — de-iconed field labels; the hardcoded `text-yellow-500` lightbulb tip becomes a calm mono-kicker **"Tips"** box (tokenized).
- **`create-edit-competition-form`** — de-iconed field labels.

The common thread: **flat surfaces** (hairline border, no drop shadow), **left-aligned headers**, and **plain-text labels** (no lucide icon per field) for a calmer, consistent input system — the "consistent inputs / spacing / labels" the issue asks for.

## Storybook
Stories for the two form primitives these surfaces are built from — **`Textarea`** (with the label + character-counter pattern) and **`Alert`** (the shared form error state). The forms themselves are router/hook-coupled, so per the design guide they're left out of Storybook; their primitives are the storybook-able pieces.

## Verification
- `tsc --noEmit` clean
- `eslint` — 0 errors, no new warnings (the 9 warnings are all pre-existing: `react-hook-form` `watch()` + unused vars in files I didn't add)
- `vitest run` — 208 passing
- `build-storybook` succeeds

## Notes
- Left the shared `PageHeading` primitive alone on purpose — it's used by 13 pages including intentionally-centered error/not-found/account pages, so a global change belongs with the "audit stragglers" pass, not here.
- Remaining #139 surfaces after this: **Admin pages**, **Polish pass**, **Audit stragglers** (`/account`, `PageHeading`).

Part of #139.

https://claude.ai/code/session_018Wc7bVR1PVzEDUoHrxoGfx

---
_Generated by [Claude Code](https://claude.ai/code/session_018Wc7bVR1PVzEDUoHrxoGfx)_