### PR TITLE
Soft-minimal remodel: admin competitions + shared PageHeading cleanup

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -8,7 +8,7 @@ export default async function Page() {
       <div className="w-full max-w-lg flex flex-col">
         <PageHeading
           title="Account Settings"
-          className="mb-2"
+          subtitle="Manage your profile and identity provider details."
         />
         <AccountDetails idpBaseUrl={idpBaseUrl} />
       </div>

--- a/app/admin/competitions/competition-row.tsx
+++ b/app/admin/competitions/competition-row.tsx
@@ -38,7 +38,7 @@ export default function CompetitionRow({
   const status = getCompetitionStatusFromObject(competition);
 
   return (
-    <div className="flex items-center justify-between p-4 border-b border-border hover:bg-muted/50 transition-colors">
+    <div className="flex items-center justify-between p-4 transition-colors hover:bg-muted/40">
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-3 mb-2">
           <div className="flex items-center gap-2">
@@ -136,14 +136,22 @@ export default function CompetitionRow({
           </div>
         </div>
       </div>
-      <div className="flex items-center gap-4 ml-4">
+      <div className="ml-4 flex items-center gap-5">
         <div className="text-right">
-          <div className="text-2xl font-bold">{nProps}</div>
-          <div className="text-xs text-muted-foreground">total props</div>
+          <div className="font-mono text-2xl font-semibold tabular-nums">
+            {nProps}
+          </div>
+          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            total props
+          </div>
         </div>
         <div className="text-right">
-          <div className="text-2xl font-bold">{nResolvedProps}</div>
-          <div className="text-xs text-muted-foreground">resolved</div>
+          <div className="font-mono text-2xl font-semibold tabular-nums">
+            {nResolvedProps}
+          </div>
+          <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            resolved
+          </div>
         </div>
       </div>
     </div>

--- a/app/admin/competitions/competition-status-badge.stories.tsx
+++ b/app/admin/competitions/competition-status-badge.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CompetitionStatusBadge } from "./competition-status-badge";
+import type { CompetitionStatus } from "@/lib/competition-status";
+
+const STATUSES: CompetitionStatus[] = [
+  "upcoming",
+  "forecasts-open",
+  "forecasts-closed",
+  "ended",
+  "private",
+];
+
+const meta = {
+  title: "Competition/CompetitionStatusBadge",
+  component: CompetitionStatusBadge,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    status: {
+      control: "select",
+      options: STATUSES,
+    },
+  },
+  args: {
+    status: "forecasts-open",
+  },
+} satisfies Meta<typeof CompetitionStatusBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+// Every lifecycle status side by side — used on both the admin competitions
+// table and the public /competitions list.
+export const AllStatuses: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2">
+      {STATUSES.map((status) => (
+        <CompetitionStatusBadge key={status} status={status} />
+      ))}
+    </div>
+  ),
+};

--- a/app/admin/competitions/page.tsx
+++ b/app/admin/competitions/page.tsx
@@ -1,9 +1,8 @@
+import Link from "next/link";
 import { getCompetitions, getProps } from "@/lib/db_actions";
 import CompetitionRow from "./competition-row";
 import CreateCompetitionButton from "./create-competition-button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Trophy } from "lucide-react";
-import PageHeading from "@/components/page-heading";
+import { Container } from "@/components/ui/container";
 
 export default async function Page() {
   const competitionsResult = await getCompetitions();
@@ -51,46 +50,52 @@ export default async function Page() {
   );
 
   return (
-    <main className="flex flex-col py-4 px-4 sm:py-6 sm:px-6 lg:py-8 lg:px-8 xl:py-12 xl:px-24">
-      <div className="w-full max-w-6xl mx-auto space-y-6 sm:space-y-8">
-        <PageHeading
-          title="Competitions"
-          breadcrumbs={{
-            Admin: "/admin",
-          }}
-          className="mb-2"
-        />
-
-        <div className="flex items-center justify-between">
-          <div className="flex gap-2 sm:gap-4">
-            <CreateCompetitionButton className="w-full sm:w-auto flex items-center justify-center gap-2 text-sm sm:text-base" />
+    <main className="py-10 lg:py-14">
+      <Container>
+        <header className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div className="min-w-0">
+            <Link
+              href="/admin"
+              className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Admin
+            </Link>
+            <h1 className="mt-1 text-2xl font-semibold tracking-tight sm:text-3xl">
+              Competitions
+            </h1>
+            <p className="mt-1.5 text-sm text-muted-foreground">
+              Create competitions and review their props and resolutions.
+            </p>
           </div>
-        </div>
+          <CreateCompetitionButton className="shrink-0" />
+        </header>
 
-        {/* Competitions Table */}
-        <Card className="shadow-lg border-0">
-          <CardHeader className="pb-3 sm:pb-4 px-4 sm:px-6">
-            <CardTitle className="flex items-center gap-2 text-lg sm:text-xl">
-              <Trophy className="h-4 w-4 sm:h-5 sm:w-5" />
-              All Competitions
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="p-0 overflow-x-auto">
-            <div className="space-y-0">
-              {competitions.map((competition) => (
-                <CompetitionRow
-                  key={competition.id}
-                  competition={competition}
-                  nProps={propCountsByCompetitionId[competition.id] ?? 0}
-                  nResolvedProps={
-                    resolvedPropCountsByCompetitionId[competition.id] ?? 0
-                  }
-                />
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+        {/* Competitions table */}
+        <section className="overflow-hidden rounded-lg border bg-card">
+          <div className="border-b px-4 py-3 sm:px-5">
+            <span className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              All Competitions ({competitions.length})
+            </span>
+          </div>
+          <div className="divide-y">
+            {competitions.map((competition) => (
+              <CompetitionRow
+                key={competition.id}
+                competition={competition}
+                nProps={propCountsByCompetitionId[competition.id] ?? 0}
+                nResolvedProps={
+                  resolvedPropCountsByCompetitionId[competition.id] ?? 0
+                }
+              />
+            ))}
+            {competitions.length === 0 && (
+              <p className="px-5 py-10 text-center text-sm text-muted-foreground">
+                No competitions yet.
+              </p>
+            )}
+          </div>
+        </section>
+      </Container>
     </main>
   );
 }

--- a/components/page-heading.stories.tsx
+++ b/components/page-heading.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import PageHeading from "./page-heading";
+import { Button } from "./ui/button";
+
+const meta = {
+  title: "UI/PageHeading",
+  component: PageHeading,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="max-w-3xl">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    title: { control: "text" },
+    subtitle: { control: "text" },
+    breadcrumbs: { control: false },
+    children: { control: false },
+  },
+  args: {
+    title: "Account Settings",
+  },
+} satisfies Meta<typeof PageHeading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TitleOnly: Story = {};
+
+export const WithSubtitle: Story = {
+  args: {
+    subtitle: "Manage your profile and identity provider details.",
+  },
+};
+
+export const WithBreadcrumbs: Story = {
+  args: {
+    title: "User Management",
+    breadcrumbs: { Admin: "/admin" },
+  },
+};
+
+// `children` is the right-aligned action slot (e.g. a primary button).
+export const WithAction: Story = {
+  args: {
+    title: "Competitions",
+    breadcrumbs: { Admin: "/admin" },
+    children: <Button size="sm">New competition</Button>,
+  },
+};
+
+export const WithEverything: Story = {
+  args: {
+    title: "Competitions",
+    subtitle: "Create competitions and review their props and resolutions.",
+    breadcrumbs: { Admin: "/admin", Competitions: "/admin/competitions" },
+    children: <Button size="sm">New competition</Button>,
+  },
+};
+
+// The title is markdown-aware (links / bold / italic render).
+export const MarkdownTitle: Story = {
+  args: {
+    title: "Results for **2026 Predictions**",
+  },
+};

--- a/components/page-heading.tsx
+++ b/components/page-heading.tsx
@@ -8,47 +8,53 @@ import {
 } from "@/components/ui/breadcrumb";
 import { MarkdownRenderer } from "@/components/markdown";
 
+/**
+ * Left-aligned page heading: optional breadcrumbs, a title (markdown-aware),
+ * an optional muted subtitle, and an optional right-aligned action slot
+ * (`children`). The soft-minimal type treatment — semibold, tight-tracked —
+ * matches the section headers used across the app.
+ */
 export default function PageHeading({
   title,
+  subtitle,
   className,
   children,
   breadcrumbs,
 }: {
   title: string;
+  /** Optional muted line rendered under the title. */
+  subtitle?: string;
   className?: string;
+  /** Optional trailing action (e.g. a button); right-aligned on sm+. */
   children?: React.ReactNode;
   breadcrumbs?: Record<string, string>;
 }) {
-  const defaultClassName = "w-full mb-8 flex flex-col items-center gap-y-1";
-  className = cn(defaultClassName, className);
   const hasBreadcrumbs = breadcrumbs && Object.keys(breadcrumbs).length > 0;
   return (
-    <header className={className}>
-      {/* Always reserve space for breadcrumbs to maintain consistent layout */}
-      <div className="flex flex-row items-start w-full min-h-[20px]">
-        {hasBreadcrumbs && (
-          <Breadcrumb>
-            <BreadcrumbList>
-              {Object.entries(breadcrumbs).map(([label, href]) => (
-                <div key={label} className="flex items-center">
-                  <BreadcrumbItem>
-                    <BreadcrumbLink href={href}>{label}</BreadcrumbLink>
-                  </BreadcrumbItem>
-                  <BreadcrumbSeparator />
-                </div>
-              ))}
-            </BreadcrumbList>
-          </Breadcrumb>
-        )}
+    <header className={cn("mb-8 w-full", className)}>
+      {hasBreadcrumbs && (
+        <Breadcrumb className="mb-2">
+          <BreadcrumbList>
+            {Object.entries(breadcrumbs).map(([label, href]) => (
+              <div key={label} className="flex items-center">
+                <BreadcrumbItem>
+                  <BreadcrumbLink href={href}>{label}</BreadcrumbLink>
+                </BreadcrumbItem>
+                <BreadcrumbSeparator />
+              </div>
+            ))}
+          </BreadcrumbList>
+        </Breadcrumb>
+      )}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+        <h1 className="min-w-0 text-2xl font-semibold tracking-tight text-foreground">
+          <MarkdownRenderer>{title}</MarkdownRenderer>
+        </h1>
+        {children && <div className="shrink-0">{children}</div>}
       </div>
-      <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 w-full">
-        <div className="min-w-0 flex items-center gap-x-4">
-          <h1 className="text-2xl font-bold inline">
-            <MarkdownRenderer>{title}</MarkdownRenderer>
-          </h1>
-          {children}
-        </div>
-      </div>
+      {subtitle && (
+        <p className="mt-1.5 text-sm text-muted-foreground">{subtitle}</p>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
Two related slices of the #139 remodel (follows #143).

## 1. Admin competitions page
- **`page`** — drops the centered `PageHeading` + `Card shadow-lg border-0` + Trophy-icon title. Now `Container` + a left-aligned header (mono "Admin" kicker, title + subtitle) and a flat table (hairline border, `divide-y` rows, mono-kicker "All Competitions (n)" header) — matching the leaderboard / members / `/competitions` language. Adds an empty state.
- **`competition-row`** — prop/resolved counts are now mono tabular with mono-kicker labels; per-row border removed in favor of the container's `divide-y`.
- **Storybook** — `CompetitionStatusBadge` story (all 5 statuses); shared by this page and the public `/competitions` list.

## 2. Shared `PageHeading` cleanup
The heading primitive that **~13 pages** share (account, admin users/feature-flags/suggested-props/forecast-progress, error / not-found / inaccessible, the prop forms). Modernizing it once cleans up every PageHeading-led page — the "audit stragglers" item.
- Title is now **semibold + tight-tracked** (was `text-2xl font-bold`); dropped the inert `items-center` and the phantom reserved breadcrumb space; breadcrumbs render only when present.
- Added an optional **`subtitle`** (muted line under the title) and turned `children` into a proper **right-aligned action slot** (no caller passed `children` before, so nothing regresses). `/account` now uses the subtitle.
- **Storybook** — `PageHeading` story (title-only / subtitle / breadcrumbs / action / everything / markdown title).

## Verification
- `tsc --noEmit` clean
- `eslint` — 0 errors, no new warnings
- `vitest run` — 208 passing
- `build-storybook` succeeds

## Scope notes
- `PageHeading` change is safe across the "centered" pages (error / not-found / inaccessible / account): they center their *column* via their own outer wrapper, and their body was already left-aligned — so the title now matches.
- Remaining admin slices (`users/*`, `feature-flags/*`, `suggested-props`, `forecast-progress`) still need their card/table bodies restyled; their headings already improve from this change.

Part of #139.

https://claude.ai/code/session_018Wc7bVR1PVzEDUoHrxoGfx