### PR TITLE
Fix GaugeGlyph vertical centering in navbar wordmark

### DIFF
--- a/components/navbar/wordmark.tsx
+++ b/components/navbar/wordmark.tsx
@@ -37,9 +37,16 @@ function GaugeGlyph() {
       className="h-5 w-[22px] shrink-0 overflow-visible"
       aria-hidden="true"
     >
+      {/*
+        The artwork is vertically centered in the 22x20 viewBox so the glyph
+        sits on the same mid-line as the adjacent wordmark under `items-center`.
+        The gauge baseline is at y=13: the arc rises ~9 units above it while the
+        hub drops ~2.75 below, centering the painted bounds on y≈10. (Authoring
+        the arc at y=15 left the glyph bottom-heavy, so it rendered low.)
+      */}
       {/* Gauge band */}
       <path
-        d="M 3 15 A 8 8 0 0 1 19 15"
+        d="M 3 13 A 8 8 0 0 1 19 13"
         fill="none"
         stroke="var(--muted-foreground)"
         strokeWidth={2}
@@ -48,9 +55,9 @@ function GaugeGlyph() {
       {/* Needle — the single indigo accent, pointing up and to the right */}
       <line
         x1={11}
-        y1={15}
+        y1={13}
         x2={14.5}
-        y2={8.2}
+        y2={6.2}
         stroke="var(--primary)"
         strokeWidth={2.5}
         strokeLinecap="round"
@@ -58,7 +65,7 @@ function GaugeGlyph() {
       {/* Hub */}
       <circle
         cx={11}
-        cy={15}
+        cy={13}
         r={2}
         fill="var(--background)"
         stroke="var(--foreground)"


### PR DESCRIPTION
## Summary

Adjusted the GaugeGlyph SVG artwork to be properly vertically centered within its 22×20 viewBox, ensuring the gauge sits on the same mid-line as the adjacent wordmark text when both are aligned with `items-center`.

## Changes

- **Gauge band arc**: Moved baseline from `y=15` to `y=13` (both start and end points)
- **Needle**: Adjusted start point from `y1=15` to `y1=13` and endpoint from `y2=8.2` to `y2=6.2` to maintain proportional angle
- **Hub circle**: Moved center from `cy=15` to `cy=13`
- **Documentation**: Added detailed comment explaining the vertical centering math (arc rises ~9 units above baseline, hub drops ~2.75 below, centering painted bounds on y≈10)

## Implementation Details

The gauge baseline was previously at y=15, which left the glyph bottom-heavy and caused it to render lower than intended. By moving the baseline to y=13, the artwork is now centered on y≈10 within the viewBox, aligning properly with the adjacent wordmark text under flexbox `items-center` alignment.

All proportions and angles are preserved—only the vertical position changed.

https://claude.ai/code/session_01JJcRoMEruMnx3LLJuDa64R