### PR TITLE
Soft-minimal remodel: admin pages (#139)

### DIFF
--- a/app/admin/admin-nav-card.stories.tsx
+++ b/app/admin/admin-nav-card.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Flag, Users } from "lucide-react";
+import { AdminNavCard } from "./admin-nav-card";
+
+const meta = {
+  title: "Admin/AdminNavCard",
+  component: AdminNavCard,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    href: "/admin/users",
+    title: "Users",
+    description: "Browse accounts, manage access, and impersonate users.",
+    icon: <Users size={18} />,
+  },
+} satisfies Meta<typeof AdminNavCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div className="w-80">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const FeatureFlags: Story = {
+  args: {
+    href: "/admin/feature-flags",
+    title: "Feature Flags",
+    description: "Toggle features globally or for individual users.",
+    icon: <Flag size={18} />,
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-80">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/** How the cards tile on the admin landing index. */
+export const Grid: Story = {
+  render: () => (
+    <div className="grid w-[40rem] grid-cols-2 gap-4">
+      <AdminNavCard
+        href="/admin/users"
+        title="Users"
+        description="Browse accounts, manage access, and impersonate users."
+        icon={<Users size={18} />}
+      />
+      <AdminNavCard
+        href="/admin/feature-flags"
+        title="Feature Flags"
+        description="Toggle features globally or for individual users."
+        icon={<Flag size={18} />}
+      />
+    </div>
+  ),
+};

--- a/app/admin/admin-nav-card.tsx
+++ b/app/admin/admin-nav-card.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
+
+export interface AdminNavCardProps {
+  href: string;
+  title: string;
+  description: string;
+  /** A small icon (e.g. a lucide glyph) shown in the card's corner badge. */
+  icon: React.ReactNode;
+}
+
+/**
+ * Flat, bordered link card for the admin landing index. Depth comes from a
+ * hairline border; hover shifts the border color (no drop shadow), matching
+ * the soft-minimal surface language.
+ */
+export function AdminNavCard({
+  href,
+  title,
+  description,
+  icon,
+}: AdminNavCardProps) {
+  return (
+    <Link
+      href={href}
+      className="group flex flex-col gap-4 rounded-lg border bg-card p-5 transition-colors hover:border-foreground/20"
+    >
+      <div className="flex items-start justify-between">
+        <span className="flex h-9 w-9 items-center justify-center rounded-md border bg-muted/40 text-muted-foreground transition-colors group-hover:text-foreground">
+          {icon}
+        </span>
+        <ArrowUpRight className="h-4 w-4 text-muted-foreground/40 transition-colors group-hover:text-foreground" />
+      </div>
+      <div>
+        <h2 className="text-sm font-semibold tracking-tight text-foreground">
+          {title}
+        </h2>
+        <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+          {description}
+        </p>
+      </div>
+    </Link>
+  );
+}

--- a/app/admin/feature-flags/feature-toggle.stories.tsx
+++ b/app/admin/feature-flags/feature-toggle.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { FeatureToggle } from "./feature-toggle";
+
+const meta = {
+  title: "Admin/FeatureToggle",
+  component: FeatureToggle,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    name: "Default",
+    checked: true,
+    onCheckedChange: fn(),
+  },
+} satisfies Meta<typeof FeatureToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const On: Story = {
+  args: { checked: true },
+};
+
+export const Off: Story = {
+  args: { checked: false },
+};
+
+/** Without an `onCheckedChange` handler the switch renders read-only. */
+export const ReadOnly: Story = {
+  args: { name: "Default", checked: true, onCheckedChange: undefined },
+};
+
+export const Unlabeled: Story = {
+  args: { name: undefined, checked: false },
+};

--- a/app/admin/feature-flags/feature-toggle.tsx
+++ b/app/admin/feature-flags/feature-toggle.tsx
@@ -12,15 +12,21 @@ export function FeatureToggle({
   onCheckedChange?: (checked: boolean) => void;
 }) {
   return (
-    <div className="flex flex-col gap-1 items-center">
-      {name && <span className="text-muted-foreground">{name}</span>}
+    <div className="flex flex-col items-center gap-1.5">
+      {name && (
+        <span className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+          {name}
+        </span>
+      )}
       <div className="flex flex-row items-center gap-2">
         <Switch
           checked={checked}
           onCheckedChange={onCheckedChange}
           disabled={onCheckedChange === undefined}
         />
-        <span>{checked ? "On" : "Off"}</span>
+        <span className="font-mono text-xs tabular-nums text-muted-foreground">
+          {checked ? "On" : "Off"}
+        </span>
       </div>
     </div>
   );

--- a/app/admin/feature-flags/feature-widget.tsx
+++ b/app/admin/feature-flags/feature-widget.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { VFeatureFlag } from "@/types/db_types";
 import { FeatureToggle } from "./feature-toggle";
 import {
@@ -35,15 +34,15 @@ export function FeatureWidget({ featureName, flags }: FeatureWidgetProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
   userValues.sort((a, b) => a.user_id! - b.user_id!);
   return (
-    <Card className="w-full">
-      <CardHeader>
-        <CardTitle className="text-lg">{featureName}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="flex flex-row justify-between items-end">
+    <div className="rounded-lg border bg-card p-4 sm:p-5">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <h2 className="min-w-0 truncate font-mono text-sm font-medium text-foreground">
+          {featureName}
+        </h2>
+        <div className="flex items-center gap-5">
           {defaultValue !== undefined ? (
             <FeatureToggle
-              name="Default Value"
+              name="Default"
               checked={defaultValue.enabled}
               onCheckedChange={async (checked) => {
                 const result = await updateFeatureFlag({
@@ -67,17 +66,19 @@ export function FeatureWidget({ featureName, flags }: FeatureWidgetProps) {
               }}
             />
           ) : (
-            <div className="flex flex-col gap-1 items-center">
-              <span className="text-muted-foreground">Default Value</span>
+            <div className="flex flex-col items-center gap-1.5">
+              <span className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                Default
+              </span>
               <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
                 <DialogTrigger asChild>
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="gap-2 font-normal"
+                    className="h-7 gap-1.5 font-normal text-muted-foreground"
                   >
-                    <span className="text-sm">None</span>
-                    <Edit size={14} />
+                    None
+                    <Edit size={13} />
                   </Button>
                 </DialogTrigger>
                 <DialogContent>
@@ -95,11 +96,9 @@ export function FeatureWidget({ featureName, flags }: FeatureWidgetProps) {
           )}
           <Popover>
             <PopoverTrigger asChild>
-              <Button
-                variant="outline"
-                className="flex flex-row justify-end gap-2"
-              >
-                {userValues.length} user-level flag
+              <Button variant="outline" size="sm">
+                <span className="tabular-nums">{userValues.length}</span>
+                &nbsp;user-level flag
                 {userValues.length != 1 && "s"}
               </Button>
             </PopoverTrigger>
@@ -111,8 +110,8 @@ export function FeatureWidget({ featureName, flags }: FeatureWidgetProps) {
             </PopoverContent>
           </Popover>
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }
 

--- a/app/admin/feature-flags/page.tsx
+++ b/app/admin/feature-flags/page.tsx
@@ -2,15 +2,17 @@ import PageHeading from "@/components/page-heading";
 import { getFeatureFlags } from "@/lib/db_actions";
 import { VFeatureFlag } from "@/types/db_types";
 import { FeatureWidget } from "./feature-widget";
+import { Container } from "@/components/ui/container";
 
 export default async function FeatureFlagsPage() {
   const result = await getFeatureFlags();
   if (!result.success) {
     return (
-      <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24 max-w-4xl mx-auto">
-        <div className="w-full flex flex-col">
-          <p className="text-destructive">Error: {result.error}</p>
-        </div>
+      <main className="py-10 lg:py-14">
+        <Container className="max-w-3xl">
+          <PageHeading title="Feature Flags" breadcrumbs={{ Admin: "/admin" }} />
+          <p className="text-sm text-destructive">Error: {result.error}</p>
+        </Container>
       </main>
     );
   }
@@ -26,24 +28,31 @@ export default async function FeatureFlagsPage() {
   const featureNames = Array.from(featureFlagsByName.keys());
   featureNames.sort();
   return (
-    <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24 max-w-4xl mx-auto">
-      <div className="w-full flex flex-col">
+    <main className="py-10 lg:py-14">
+      <Container className="max-w-3xl">
         <PageHeading
           title="Feature Flags"
-          breadcrumbs={{
-            Admin: "/admin",
-          }}
+          subtitle="Toggle features globally or for individual users."
+          breadcrumbs={{ Admin: "/admin" }}
         />
-        <div className="flex flex-col gap-2">
-          {featureNames.map((name) => (
-            <FeatureWidget
-              key={name}
-              featureName={name}
-              flags={featureFlagsByName.get(name)!}
-            />
-          ))}
-        </div>
-      </div>
+        {featureNames.length === 0 ? (
+          <div className="rounded-lg border bg-card p-10 text-center">
+            <p className="text-sm text-muted-foreground">
+              No feature flags defined.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {featureNames.map((name) => (
+              <FeatureWidget
+                key={name}
+                featureName={name}
+                flags={featureFlagsByName.get(name)!}
+              />
+            ))}
+          </div>
+        )}
+      </Container>
     </main>
   );
 }

--- a/app/admin/feature-flags/user-level-flags-container.tsx
+++ b/app/admin/feature-flags/user-level-flags-container.tsx
@@ -56,9 +56,12 @@ export function UserLevelFlagsContainer({
       {flags.map((flag, index) => (
         <div key={flag.user_id} className="flex flex-col gap-2">
           {index > 0 && <Separator />}
-          <div className="flex flex-row justify-between px-2">
-            <span>
-              {flag.user_id} ({flag.user_name})
+          <div className="flex flex-row items-center justify-between gap-3 px-2">
+            <span className="min-w-0 truncate text-sm">
+              <span className="font-mono tabular-nums text-muted-foreground">
+                {flag.user_id}
+              </span>{" "}
+              {flag.user_name}
             </span>
             <FeatureToggle
               checked={flag.enabled}

--- a/app/admin/forecast-progress/[competitionId]/forecast-progress-meter.stories.tsx
+++ b/app/admin/forecast-progress/[competitionId]/forecast-progress-meter.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ForecastProgressMeter } from "./forecast-progress-meter";
+
+const meta = {
+  title: "Admin/ForecastProgressMeter",
+  component: ForecastProgressMeter,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    value: { control: { type: "range", min: 0, max: 1, step: 0.01 } },
+  },
+  args: {
+    value: 0.6,
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-48">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ForecastProgressMeter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Complete: Story = {
+  args: { value: 1 },
+};
+
+export const NotStarted: Story = {
+  args: { value: 0 },
+};
+
+/** The full range of fills, from not-started through complete. */
+export const Steps: Story = {
+  render: () => (
+    <div className="flex w-48 flex-col gap-3">
+      {[0, 0.25, 0.5, 0.8, 1].map((v) => (
+        <ForecastProgressMeter key={v} value={v} />
+      ))}
+    </div>
+  ),
+};

--- a/app/admin/forecast-progress/[competitionId]/forecast-progress-meter.tsx
+++ b/app/admin/forecast-progress/[competitionId]/forecast-progress-meter.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Compact horizontal progress meter for the forecast-progress table. `value`
+ * is a fraction in [0, 1]. Completed rows read in the semantic `success`
+ * color; partial rows use a neutral fill — no decorative green/yellow ramp.
+ */
+export function ForecastProgressMeter({ value }: { value: number }) {
+  const clamped = Math.max(0, Math.min(1, value));
+  const pct = Math.round(clamped * 100);
+  const complete = clamped >= 1;
+  const started = clamped > 0;
+
+  return (
+    <div className="flex items-center justify-end gap-2.5">
+      <div className="hidden h-1.5 w-24 overflow-hidden rounded-full bg-muted sm:block">
+        <div
+          className={cn(
+            "h-full rounded-full transition-all",
+            complete ? "bg-success" : "bg-muted-foreground/40",
+          )}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span
+        className={cn(
+          "min-w-[2.75rem] text-right font-mono text-sm tabular-nums",
+          complete
+            ? "text-success-muted-foreground"
+            : started
+              ? "text-foreground"
+              : "text-muted-foreground",
+        )}
+      >
+        {pct}%
+      </span>
+    </div>
+  );
+}

--- a/app/admin/forecast-progress/[competitionId]/loading.tsx
+++ b/app/admin/forecast-progress/[competitionId]/loading.tsx
@@ -1,15 +1,19 @@
 import PageHeading from "@/components/page-heading";
 import { Spinner } from "@/components/ui/spinner";
+import { Container } from "@/components/ui/container";
 
-export default async function Loading() {
+export default function Loading() {
   return (
-    <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
-      <div className="w-full max-w-lg">
-        <PageHeading title="Forecast Progress"></PageHeading>
-        <div className="flex justify-center items-center h-[32rem]">
-          <Spinner className="w-24 h-24 text-muted-foreground" />
+    <main className="py-10 lg:py-14">
+      <Container>
+        <PageHeading
+          title="Forecast Progress"
+          breadcrumbs={{ Admin: "/admin" }}
+        />
+        <div className="flex h-80 items-center justify-center rounded-lg border bg-card">
+          <Spinner className="h-10 w-10 text-muted-foreground" />
         </div>
-      </div>
+      </Container>
     </main>
   );
 }

--- a/app/admin/forecast-progress/[competitionId]/page.tsx
+++ b/app/admin/forecast-progress/[competitionId]/page.tsx
@@ -9,10 +9,10 @@ import { VUser } from "@/types/db_types";
 import { InaccessiblePage } from "@/components/inaccessible-page";
 import ErrorPage from "@/components/pages/error-page";
 import { handleServerActionResult } from "@/lib/server-action-helpers";
-import { ClipboardCheck, Users } from "lucide-react";
 import { logger } from "@/lib/logger";
 import { ErrorToast } from "./error-toast";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Container } from "@/components/ui/container";
+import { ForecastProgressMeter } from "./forecast-progress-meter";
 import {
   Table,
   TableBody,
@@ -127,76 +127,60 @@ export default async function ForecastProgressPage({
   const usersFinished = metrics.filter((m) => m.percentComplete === 1).length;
 
   return (
-    <main className="flex flex-col py-4 px-4 sm:py-6 sm:px-6 lg:py-8 lg:px-8 xl:py-12 xl:px-24">
-      <div className="w-full max-w-6xl mx-auto space-y-6 sm:space-y-8">
+    <main className="py-10 lg:py-14">
+      <Container>
         <ErrorToast hasErrors={hasErrors} />
         <PageHeading
-          title={`${competition?.name}: Forecast Progress`}
+          title="Forecast Progress"
+          subtitle={competition?.name}
           breadcrumbs={{
             Admin: "/admin",
           }}
-          className="mb-2"
         />
 
-        {/* Stats Cards */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
-          <Card className="border-0 bg-gradient-to-br from-blue-50 to-blue-100 dark:from-blue-950 dark:to-blue-900">
-            <CardContent className="pt-4 sm:pt-6 px-4 sm:px-6">
-              <div className="flex items-center justify-between">
-                <div className="min-w-0 flex-1">
-                  <p className="text-xs sm:text-sm font-medium text-blue-600 dark:text-blue-400">
-                    Overall Progress
-                  </p>
-                  <p className="text-xl sm:text-2xl font-bold text-blue-900 dark:text-blue-100">
-                    {(overallProgress * 100).toFixed(0)}%
-                  </p>
-                </div>
-                <div className="w-6 h-6 sm:w-8 sm:h-8 bg-blue-500 rounded-full flex items-center justify-center flex-shrink-0">
-                  <ClipboardCheck className="h-3 w-3 sm:h-4 sm:w-4 text-white" />
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+        {/* Summary stats */}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="rounded-lg border bg-card p-4">
+            <div className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+              Overall Progress
+            </div>
+            <div className="mt-1.5 font-mono text-3xl font-semibold tabular-nums tracking-tight text-foreground">
+              {(overallProgress * 100).toFixed(0)}%
+            </div>
+          </div>
 
-          <Card className="border-0 bg-gradient-to-br from-green-50 to-green-100 dark:from-green-950 dark:to-green-900">
-            <CardContent className="pt-4 sm:pt-6 px-4 sm:px-6">
-              <div className="flex items-center justify-between">
-                <div className="min-w-0 flex-1">
-                  <p className="text-xs sm:text-sm font-medium text-green-600 dark:text-green-400">
-                    Users Finished
-                  </p>
-                  <p className="text-xl sm:text-2xl font-bold text-green-900 dark:text-green-100">
-                    {usersFinished} / {totalUsers}
-                  </p>
-                </div>
-                <Users className="h-6 w-6 sm:h-8 sm:w-8 text-green-500 flex-shrink-0" />
-              </div>
-            </CardContent>
-          </Card>
+          <div className="rounded-lg border bg-card p-4">
+            <div className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+              Users Finished
+            </div>
+            <div className="mt-1.5 font-mono text-3xl font-semibold tabular-nums tracking-tight text-foreground">
+              {usersFinished}
+              <span className="text-muted-foreground"> / {totalUsers}</span>
+            </div>
+          </div>
         </div>
 
-        {/* Progress Table */}
-        <Card className="shadow-lg border-0">
-          <CardHeader className="pb-3 sm:pb-4 px-4 sm:px-6">
-            <CardTitle className="flex items-center gap-2 text-lg sm:text-xl">
-              <ClipboardCheck className="h-4 w-4 sm:h-5 sm:w-5" />
-              User Progress
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="p-0 overflow-x-auto">
+        {/* Progress table */}
+        <section className="mt-6 overflow-hidden rounded-lg border bg-card">
+          <div className="border-b px-4 py-3 sm:px-5">
+            <span className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              User Progress (<span className="tabular-nums">{totalUsers}</span>)
+            </span>
+          </div>
+          <div className="overflow-x-auto">
             <Table>
               <TableHeader className="bg-muted/30">
-                <TableRow className="border-b">
-                  <TableHead className="font-semibold text-muted-foreground text-xs sm:text-sm">
+                <TableRow className="border-b hover:bg-transparent">
+                  <TableHead className="font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
                     User
                   </TableHead>
-                  <TableHead className="font-semibold text-muted-foreground text-xs sm:text-sm text-right">
+                  <TableHead className="text-right font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
                     Unforecasted
                   </TableHead>
-                  <TableHead className="font-semibold text-muted-foreground text-xs sm:text-sm text-right">
+                  <TableHead className="text-right font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
                     Forecasted
                   </TableHead>
-                  <TableHead className="font-semibold text-muted-foreground text-xs sm:text-sm text-right">
+                  <TableHead className="text-right font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
                     Progress
                   </TableHead>
                 </TableRow>
@@ -207,9 +191,9 @@ export default async function ForecastProgressPage({
                 ))}
               </TableBody>
             </Table>
-          </CardContent>
-        </Card>
-      </div>
+          </div>
+        </section>
+      </Container>
     </main>
   );
 }
@@ -221,51 +205,20 @@ interface UserProgressMetrics {
   percentComplete: number;
 }
 
-async function UserMetricsRow({ metrics }: { metrics: UserProgressMetrics }) {
-  const percentComplete = metrics.percentComplete * 100;
-  const isComplete = metrics.percentComplete === 1;
-  const isInProgress =
-    metrics.percentComplete > 0 && metrics.percentComplete < 1;
-
+function UserMetricsRow({ metrics }: { metrics: UserProgressMetrics }) {
   return (
-    <TableRow className="border-b hover:bg-muted/20 transition-colors">
-      <TableCell className="py-3 sm:py-4 text-xs sm:text-sm font-medium">
+    <TableRow className="hover:bg-muted/30">
+      <TableCell className="py-3 text-sm font-medium">
         {metrics.user.name}
       </TableCell>
-      <TableCell className="py-3 sm:py-4 text-xs sm:text-sm text-right">
+      <TableCell className="py-3 text-right font-mono text-sm tabular-nums text-muted-foreground">
         {metrics.unforecasted}
       </TableCell>
-      <TableCell className="py-3 sm:py-4 text-xs sm:text-sm text-right">
+      <TableCell className="py-3 text-right font-mono text-sm tabular-nums">
         {metrics.forecasted}
       </TableCell>
-      <TableCell className="py-3 sm:py-4 text-xs sm:text-sm text-right">
-        <div className="flex items-center justify-end gap-2">
-          <div className="flex-1 max-w-[100px] hidden sm:block">
-            <div className="h-2 bg-muted rounded-full overflow-hidden">
-              <div
-                className={`h-full transition-all ${
-                  isComplete
-                    ? "bg-green-500"
-                    : isInProgress
-                      ? "bg-yellow-500"
-                      : "bg-muted"
-                }`}
-                style={{ width: `${percentComplete}%` }}
-              />
-            </div>
-          </div>
-          <span
-            className={`font-medium ${
-              isComplete
-                ? "text-green-600 dark:text-green-400"
-                : isInProgress
-                  ? "text-yellow-600 dark:text-yellow-400"
-                  : "text-muted-foreground"
-            }`}
-          >
-            {percentComplete.toFixed(0)}%
-          </span>
-        </div>
+      <TableCell className="py-3 text-right">
+        <ForecastProgressMeter value={metrics.percentComplete} />
       </TableCell>
     </TableRow>
   );

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,65 @@
+import { Container } from "@/components/ui/container";
+import {
+  BarChartHorizontal,
+  Flag,
+  Medal,
+  MessageCircle,
+  Users,
+} from "lucide-react";
+import { AdminNavCard, type AdminNavCardProps } from "./admin-nav-card";
+
+const ADMIN_SECTIONS: AdminNavCardProps[] = [
+  {
+    href: "/admin/users",
+    title: "Users",
+    description: "Browse accounts, manage access, and impersonate users.",
+    icon: <Users size={18} />,
+  },
+  {
+    href: "/admin/competitions",
+    title: "Competitions",
+    description: "Create competitions and review their props and resolutions.",
+    icon: <Medal size={18} />,
+  },
+  {
+    href: "/admin/feature-flags",
+    title: "Feature Flags",
+    description: "Toggle features globally or for individual users.",
+    icon: <Flag size={18} />,
+  },
+  {
+    href: "/admin/suggested-props",
+    title: "Suggested Props",
+    description: "Review propositions submitted by forecasters.",
+    icon: <MessageCircle size={18} />,
+  },
+  {
+    href: "/admin/forecast-progress/6",
+    title: "Forecast Progress",
+    description: "See how far along each forecaster is in a competition.",
+    icon: <BarChartHorizontal size={18} />,
+  },
+];
+
+export default function AdminIndexPage() {
+  return (
+    <main className="py-10 lg:py-14">
+      <Container>
+        <header className="mb-8">
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+            Admin
+          </h1>
+          <p className="mt-1.5 text-sm text-muted-foreground">
+            Manage users, competitions, and platform configuration.
+          </p>
+        </header>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {ADMIN_SECTIONS.map((section) => (
+            <AdminNavCard key={section.href} {...section} />
+          ))}
+        </div>
+      </Container>
+    </main>
+  );
+}

--- a/app/admin/suggested-props/page.tsx
+++ b/app/admin/suggested-props/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import PageHeading from "@/components/page-heading";
 import { getSuggestedProps, deleteSuggestedProp } from "@/lib/db_actions";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Container } from "@/components/ui/container";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import {
@@ -14,7 +14,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { User, MessageSquare, Trash } from "lucide-react";
+import { User, Trash } from "lucide-react";
 import { VSuggestedProp } from "@/types/db_types";
 import {
   useServerAction,
@@ -82,87 +82,73 @@ export default function SuggestedProps() {
   };
 
   return (
-    <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
-      <div className="w-full max-w-4xl">
+    <main className="py-10 lg:py-14">
+      <Container className="max-w-3xl">
         <PageHeading
           title="Suggested Props"
+          subtitle="Review propositions submitted by forecasters."
           breadcrumbs={{
             Admin: "/admin",
           }}
         />
 
         {loading ? (
-          <Card>
-            <CardContent className="text-center py-12">
-              <Spinner className="h-8 w-8 mx-auto" />
-              <p className="text-muted-foreground mt-4">
-                Loading suggested props...
-              </p>
-            </CardContent>
-          </Card>
+          <div className="rounded-lg border bg-card p-12 text-center">
+            <Spinner className="mx-auto h-7 w-7 text-muted-foreground" />
+            <p className="mt-3 text-sm text-muted-foreground">
+              Loading suggested props…
+            </p>
+          </div>
         ) : suggestedProps.length === 0 ? (
-          <Card>
-            <CardContent className="text-center py-12">
-              <MessageSquare className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-              <h3 className="text-lg font-medium mb-2">No suggested props</h3>
-              <p className="text-muted-foreground">
-                No propositions have been suggested yet.
-              </p>
-            </CardContent>
-          </Card>
+          <div className="rounded-lg border bg-card p-12 text-center">
+            <p className="text-sm font-medium text-foreground">
+              No suggested props
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              No propositions have been suggested yet.
+            </p>
+          </div>
         ) : (
-          <div className="space-y-6">
+          <div className="space-y-4">
             {suggestedProps.map((prop) => {
               const { mainText, notes } = parsePropText(prop.prop_text);
 
               return (
-                <Card
+                <div
                   key={prop.id}
-                  className="hover:shadow-md transition-shadow"
+                  className="rounded-lg border bg-card p-5 transition-colors hover:border-foreground/20"
                 >
-                  <CardHeader>
-                    <div className="flex items-start justify-between">
-                      <div className="flex-1">
-                        <CardTitle className="text-lg leading-relaxed mb-3">
-                          <MarkdownRenderer>{mainText}</MarkdownRenderer>
-                        </CardTitle>
-
-                        <div className="flex items-center gap-4 text-sm text-muted-foreground">
-                          <div className="flex items-center gap-1">
-                            <User className="h-4 w-4" />
-                            <span className="font-medium">
-                              {prop.user_name}
-                            </span>
-                          </div>
-                        </div>
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="min-w-0 flex-1">
+                      <div className="text-base font-medium leading-relaxed text-foreground">
+                        <MarkdownRenderer>{mainText}</MarkdownRenderer>
                       </div>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="text-muted-foreground hover:text-destructive h-8 w-8"
-                        onClick={() => openDeleteDialog(prop.id)}
-                      >
-                        <Trash className="h-4 w-4" />
-                      </Button>
+                      <div className="mt-3 flex items-center gap-1.5 text-sm text-muted-foreground">
+                        <User className="h-3.5 w-3.5" />
+                        <span>{prop.user_name}</span>
+                      </div>
                     </div>
-                  </CardHeader>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+                      onClick={() => openDeleteDialog(prop.id)}
+                    >
+                      <Trash className="h-4 w-4" />
+                    </Button>
+                  </div>
 
                   {notes && (
-                    <CardContent className="pt-0">
-                      <div className="mt-3 pt-3 border-t border-border/50">
-                        <div className="flex items-center gap-2 mb-2">
-                          <MessageSquare className="h-4 w-4 text-muted-foreground" />
-                          <span className="text-sm font-medium text-muted-foreground">
-                            Additional Notes
-                          </span>
-                        </div>
-                        <div className="text-sm text-muted-foreground leading-relaxed pl-6">
-                          <MarkdownRenderer>{notes}</MarkdownRenderer>
-                        </div>
+                    <div className="mt-4 border-t pt-4">
+                      <div className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                        Notes
                       </div>
-                    </CardContent>
+                      <div className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                        <MarkdownRenderer>{notes}</MarkdownRenderer>
+                      </div>
+                    </div>
                   )}
-                </Card>
+                </div>
               );
             })}
           </div>
@@ -202,7 +188,7 @@ export default function SuggestedProps() {
             </DialogFooter>
           </DialogContent>
         </Dialog>
-      </div>
+      </Container>
     </main>
   );
 }

--- a/app/admin/users/[userId]/page.tsx
+++ b/app/admin/users/[userId]/page.tsx
@@ -2,6 +2,7 @@ import { getUserById } from "@/lib/db_actions";
 import { handleServerActionResult } from "@/lib/server-action-helpers";
 import { redirect } from "next/navigation";
 import UserDetailCard from "./user-detail-card";
+import { Container } from "@/components/ui/container";
 import PageHeading from "@/components/page-heading";
 
 interface PageProps {
@@ -24,17 +25,17 @@ export default async function UserDetailPage({ params }: PageProps) {
   }
 
   return (
-    <main className="flex flex-col items-center py-8 px-8 lg:py-12 lg:px-24">
-      <div className="w-full max-w-4xl">
+    <main className="py-10 lg:py-14">
+      <Container className="max-w-3xl">
         <PageHeading
-          title={user.name}
+          title={user.name ?? "User"}
           breadcrumbs={{
             Admin: "/admin",
             Users: "/admin/users",
           }}
         />
         <UserDetailCard user={user} />
-      </div>
+      </Container>
     </main>
   );
 }

--- a/app/admin/users/[userId]/user-detail-card.tsx
+++ b/app/admin/users/[userId]/user-detail-card.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { VUser } from "@/types/db_types";
-import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,7 +11,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Copy, Shield, User, UserCheck, UserX } from "lucide-react";
+import { Copy, User, UserCheck, UserX } from "lucide-react";
 import { setUserActive } from "@/lib/db_actions/users";
 import { getBrowserTimezone } from "@/hooks/getBrowserTimezone";
 import { formatDate, formatDateTime } from "@/lib/time-utils";
@@ -23,9 +21,46 @@ import { toast } from "@/hooks/use-toast";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
+import { UserRoleBadge, UserStatusBadge } from "../user-badges";
 
 interface UserDetailCardProps {
   user: VUser;
+}
+
+/** A label/value row inside the details panel. Label is a mono kicker. */
+function DetailRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 px-4 py-3 sm:px-5">
+      <span className="shrink-0 font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+      </span>
+      <div className="flex min-w-0 items-center justify-end gap-2 text-sm">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function CopyButton({ value, label }: { value: string; label: string }) {
+  return (
+    <Button
+      size="sm"
+      variant="ghost"
+      className="h-6 w-6 shrink-0 p-0 text-muted-foreground"
+      onClick={() => {
+        navigator.clipboard.writeText(value);
+        toast({ title: "Copied", description: `${label} copied to clipboard` });
+      }}
+    >
+      <Copy className="h-3 w-3" />
+    </Button>
+  );
 }
 
 export default function UserDetailCard({ user }: UserDetailCardProps) {
@@ -96,188 +131,116 @@ export default function UserDetailCard({ user }: UserDetailCardProps) {
   };
 
   return (
-    <div className="flex flex-col items-center">
-      {/* Avatar above card */}
-      {user.picture_url && (
-        <div className="mb-4">
+    <div className="space-y-6">
+      {/* Identity header */}
+      <div className="flex items-center gap-4 rounded-lg border bg-card p-5">
+        {user.picture_url ? (
           <Image
             src={user.picture_url}
             alt={`${user.name}'s avatar`}
-            width={144}
-            height={144}
-            className="rounded-full object-cover border-4 border-background shadow-lg"
+            width={64}
+            height={64}
+            className="h-16 w-16 rounded-full border border-border object-cover"
           />
-        </div>
-      )}
-
-      <Card className="w-full">
-        <CardHeader className="flex flex-row">
-          {/* Badges at top */}
-          {user.is_admin ? (
-            <Badge variant="default" className="bg-red-100 text-red-800">
-              <Shield className="h-3 w-3 mr-1" />
-              Admin
-            </Badge>
-          ) : (
-            <Badge variant="secondary">Regular User</Badge>
-          )}
-          <Badge
-            className={
-              isActive
-                ? "bg-green-100 text-green-800"
-                : "bg-gray-100 text-gray-800"
-            }
-            variant="outline"
-          >
-            {isActive ? "Active" : "Inactive"}
-          </Badge>
-        </CardHeader>
-        <CardContent className="pt-4">
-          <div className="space-y-4">
-            <div className="flex justify-between items-center py-2 border-b border-border">
-              <span className="text-sm font-medium text-muted-foreground">
-                Username
-              </span>
-              <div className="flex items-center gap-2">
-                {user.username ? (
-                  <>
-                    <span className="text-sm">{user.username}</span>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="h-6 w-6 p-0"
-                      onClick={() => {
-                        navigator.clipboard.writeText(user.username!);
-                        toast({
-                          title: "Copied",
-                          description: "Username copied to clipboard",
-                        });
-                      }}
-                    >
-                      <Copy className="h-3 w-3" />
-                    </Button>
-                  </>
-                ) : (
-                  <span className="text-sm text-muted-foreground">None</span>
-                )}
-              </div>
-            </div>
-
-            <div className="flex justify-between items-center py-2 border-b border-border">
-              <span className="text-sm font-medium text-muted-foreground">
-                Email
-              </span>
-              <span className="text-sm">{user.email || "None"}</span>
-            </div>
-
-            <div className="flex justify-between items-center py-2 border-b border-border">
-              <span className="text-sm font-medium text-muted-foreground">
-                Photo
-              </span>
-              {user.picture_url ? (
-                <a
-                  href={user.picture_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-primary hover:underline truncate max-w-48"
-                >
-                  {user.picture_url}
-                </a>
-              ) : (
-                <span className="text-sm text-muted-foreground">None</span>
-              )}
-            </div>
-
-            <div className="flex justify-between items-center py-2 border-b border-border">
-              <span className="text-sm font-medium text-muted-foreground">
-                Created
-              </span>
-              <span className="text-sm">
-                {formatDate(new Date(user.created_at), timezone)}
-              </span>
-            </div>
-
-            <div className="flex justify-between items-center py-2 border-b border-border">
-              <span className="text-sm font-medium text-muted-foreground">
-                Updated
-              </span>
-              <span className="text-sm">
-                {formatDate(new Date(user.updated_at), timezone)}
-              </span>
-            </div>
-
-            {!isActive && user.deactivated_at && (
-              <div className="flex justify-between items-center py-2 border-b border-border">
-                <span className="text-sm font-medium text-muted-foreground">
-                  Deactivated
-                </span>
-                <span className="text-sm">
-                  {formatDateTime(new Date(user.deactivated_at), timezone)}
-                </span>
-              </div>
-            )}
-
-            <div className="flex justify-between items-center py-2 border-b border-border">
-              <span className="text-sm font-medium text-muted-foreground">
-                User ID
-              </span>
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-mono bg-muted px-2 py-1 rounded">
-                  {user.id}
-                </span>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-6 w-6 p-0"
-                  onClick={() => {
-                    navigator.clipboard.writeText(user.id.toString());
-                    toast({
-                      title: "Copied",
-                      description: "User ID copied to clipboard",
-                    });
-                  }}
-                >
-                  <Copy className="h-3 w-3" />
-                </Button>
-              </div>
-            </div>
-
-            <div className="flex justify-between items-center py-2 border-b border-border">
-              <span className="text-sm font-medium text-muted-foreground">
-                IDP User ID
-              </span>
-              <div className="flex items-center gap-2">
-                {user.idp_user_id ? (
-                  <>
-                    <span className="text-sm font-mono bg-muted px-2 py-1 rounded truncate max-w-48">
-                      {user.idp_user_id}
-                    </span>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="h-6 w-6 p-0"
-                      onClick={() => {
-                        navigator.clipboard.writeText(user.idp_user_id!);
-                        toast({
-                          title: "Copied",
-                          description: "IDP User ID copied to clipboard",
-                        });
-                      }}
-                    >
-                      <Copy className="h-3 w-3" />
-                    </Button>
-                  </>
-                ) : (
-                  <span className="text-sm text-muted-foreground">None</span>
-                )}
-              </div>
-            </div>
-
+        ) : (
+          <div className="flex h-16 w-16 items-center justify-center rounded-full border border-border bg-muted text-xl font-medium text-foreground">
+            {user.name?.charAt(0).toUpperCase()}
           </div>
-        </CardContent>
+        )}
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate text-lg font-semibold tracking-tight">
+            {user.name}
+          </h2>
+          {user.email && (
+            <p className="truncate text-sm text-muted-foreground">
+              {user.email}
+            </p>
+          )}
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <UserRoleBadge isAdmin={user.is_admin} />
+            <UserStatusBadge active={isActive} />
+          </div>
+        </div>
+      </div>
 
-      {/* Actions Section */}
-      <CardFooter className="flex flex-row gap-4 justify-center mt-10">
+      {/* Account details */}
+      <div className="overflow-hidden rounded-lg border bg-card">
+        <div className="border-b px-4 py-3 sm:px-5">
+          <span className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+            Account Details
+          </span>
+        </div>
+        <div className="divide-y">
+          <DetailRow label="Username">
+            {user.username ? (
+              <>
+                <span className="truncate">{user.username}</span>
+                <CopyButton value={user.username} label="Username" />
+              </>
+            ) : (
+              <span className="text-muted-foreground">None</span>
+            )}
+          </DetailRow>
+
+          <DetailRow label="Email">
+            <span className="truncate">{user.email || "None"}</span>
+          </DetailRow>
+
+          <DetailRow label="Photo">
+            {user.picture_url ? (
+              <a
+                href={user.picture_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="truncate text-primary hover:underline"
+              >
+                {user.picture_url}
+              </a>
+            ) : (
+              <span className="text-muted-foreground">None</span>
+            )}
+          </DetailRow>
+
+          <DetailRow label="Created">
+            <span className="font-mono tabular-nums">
+              {formatDate(new Date(user.created_at), timezone)}
+            </span>
+          </DetailRow>
+
+          <DetailRow label="Updated">
+            <span className="font-mono tabular-nums">
+              {formatDate(new Date(user.updated_at), timezone)}
+            </span>
+          </DetailRow>
+
+          {!isActive && user.deactivated_at && (
+            <DetailRow label="Deactivated">
+              <span className="font-mono tabular-nums">
+                {formatDateTime(new Date(user.deactivated_at), timezone)}
+              </span>
+            </DetailRow>
+          )}
+
+          <DetailRow label="User ID">
+            <span className="font-mono tabular-nums">{user.id}</span>
+            <CopyButton value={user.id.toString()} label="User ID" />
+          </DetailRow>
+
+          <DetailRow label="IDP User ID">
+            {user.idp_user_id ? (
+              <>
+                <span className="truncate font-mono">{user.idp_user_id}</span>
+                <CopyButton value={user.idp_user_id} label="IDP User ID" />
+              </>
+            ) : (
+              <span className="text-muted-foreground">None</span>
+            )}
+          </DetailRow>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-wrap items-center gap-3">
         {canImpersonate && (
           <Dialog
             open={isImpersonateDialogOpen}
@@ -285,7 +248,7 @@ export default function UserDetailCard({ user }: UserDetailCardProps) {
           >
             <DialogTrigger asChild>
               <Button variant="outline" size="sm" disabled={isLoading}>
-                <User className="h-4 w-4 mr-2" />
+                <User className="mr-2 h-4 w-4" />
                 Impersonate
               </Button>
             </DialogTrigger>
@@ -294,8 +257,8 @@ export default function UserDetailCard({ user }: UserDetailCardProps) {
                 <DialogTitle>Impersonate User?</DialogTitle>
                 <DialogDescription>
                   You will view the app as {user.name}. Your admin session
-                  remains active - click &quot;Stop Impersonating&quot; in
-                  the banner to return to your own view.
+                  remains active - click &quot;Stop Impersonating&quot; in the
+                  banner to return to your own view.
                 </DialogDescription>
               </DialogHeader>
               <DialogFooter>
@@ -313,10 +276,7 @@ export default function UserDetailCard({ user }: UserDetailCardProps) {
           </Dialog>
         )}
 
-        <Dialog
-          open={isStatusDialogOpen}
-          onOpenChange={setIsStatusDialogOpen}
-        >
+        <Dialog open={isStatusDialogOpen} onOpenChange={setIsStatusDialogOpen}>
           <DialogTrigger asChild>
             <Button
               variant={isActive ? "destructive" : "outline"}
@@ -325,12 +285,12 @@ export default function UserDetailCard({ user }: UserDetailCardProps) {
             >
               {isActive ? (
                 <>
-                  <UserX className="h-4 w-4 mr-2" />
+                  <UserX className="mr-2 h-4 w-4" />
                   Deactivate
                 </>
               ) : (
                 <>
-                  <UserCheck className="h-4 w-4 mr-2" />
+                  <UserCheck className="mr-2 h-4 w-4" />
                   Activate
                 </>
               )}
@@ -364,8 +324,7 @@ export default function UserDetailCard({ user }: UserDetailCardProps) {
             </DialogFooter>
           </DialogContent>
         </Dialog>
-      </CardFooter>
-      </Card>
+      </div>
     </div>
   );
 }

--- a/app/admin/users/columns.tsx
+++ b/app/admin/users/columns.tsx
@@ -2,15 +2,15 @@
 
 import { ColumnDef } from "@tanstack/react-table";
 import { VUser } from "@/types/db_types";
-import { Badge } from "@/components/ui/badge";
 import { UserNameCell } from "./user-name-cell";
 import { UserStatusCell } from "./user-status-cell";
+import { UserRoleBadge } from "./user-badges";
 
 export function getColumns(): ColumnDef<VUser>[] {
   return [
     {
       accessorKey: "name",
-      header: () => <div className="px-2">Name</div>,
+      header: () => <span className="px-2">Name</span>,
       cell: ({ row }) => <UserNameCell user={row.original} />,
     },
     {
@@ -20,16 +20,10 @@ export function getColumns(): ColumnDef<VUser>[] {
     },
     {
       accessorKey: "is_admin",
-      header: "Admin",
+      header: "Role",
       cell: ({ row }) => (
         <div className="px-2">
-          {row.original.is_admin ? (
-            <Badge variant="outline" className="text-xs">
-              Admin
-            </Badge>
-          ) : (
-            <span className="text-xs text-muted-foreground">User</span>
-          )}
+          <UserRoleBadge isAdmin={row.original.is_admin} />
         </div>
       ),
     },
@@ -39,7 +33,7 @@ export function getColumns(): ColumnDef<VUser>[] {
       cell: ({ row }) =>
         row.original.email && (
           <div
-            className="px-2 truncate text-xs sm:text-sm"
+            className="px-2 truncate text-xs text-muted-foreground sm:text-sm"
             title={row.original.email}
           >
             {row.original.email}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,7 +1,7 @@
 import UsersTable from "./users-table";
 import { getUsers } from "@/lib/db_actions";
 import { handleServerActionResult } from "@/lib/server-action-helpers";
-import { Card, CardContent } from "@/components/ui/card";
+import { Container } from "@/components/ui/container";
 import PageHeading from "@/components/page-heading";
 
 export default async function Page() {
@@ -11,21 +11,25 @@ export default async function Page() {
   users.sort((a, b) => a.id - b.id);
 
   return (
-    <main className="flex flex-col items-center py-8 px-8 lg:py-12 lg:px-24">
-      <div className="w-full max-w-6xl">
+    <main className="py-10 lg:py-14">
+      <Container>
         <PageHeading
-          title="User Management"
-          breadcrumbs={{
-            Admin: "/admin",
-          }}
+          title="Users"
+          subtitle="Browse accounts, manage access, and impersonate users."
+          breadcrumbs={{ Admin: "/admin" }}
         />
 
-        <Card>
-          <CardContent className="p-0 overflow-x-auto">
+        <section className="overflow-hidden rounded-lg border bg-card">
+          <div className="border-b px-4 py-3 sm:px-5">
+            <span className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              All Users (<span className="tabular-nums">{users.length}</span>)
+            </span>
+          </div>
+          <div className="overflow-x-auto">
             <UsersTable data={users} />
-          </CardContent>
-        </Card>
-      </div>
+          </div>
+        </section>
+      </Container>
     </main>
   );
 }

--- a/app/admin/users/user-badges.stories.tsx
+++ b/app/admin/users/user-badges.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { UserRoleBadge, UserStatusBadge } from "./user-badges";
+
+const meta = {
+  title: "Admin/UserBadges",
+  component: UserRoleBadge,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    isAdmin: true,
+  },
+} satisfies Meta<typeof UserRoleBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The role pill: indigo Admin vs. neutral User. */
+export const Role: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2">
+      <UserRoleBadge isAdmin />
+      <UserRoleBadge isAdmin={false} />
+    </div>
+  ),
+};
+
+/** The account-status pill: success-tinted Active vs. neutral Inactive. */
+export const Status: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2">
+      <UserStatusBadge active />
+      <UserStatusBadge active={false} />
+    </div>
+  ),
+};
+
+/** Every admin user badge side by side. */
+export const AllBadges: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2">
+      <UserRoleBadge isAdmin />
+      <UserRoleBadge isAdmin={false} />
+      <UserStatusBadge active />
+      <UserStatusBadge active={false} />
+    </div>
+  ),
+};

--- a/app/admin/users/user-badges.tsx
+++ b/app/admin/users/user-badges.tsx
@@ -1,0 +1,49 @@
+import { Shield } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+/**
+ * Admin vs. regular-user role pill. Admins get an indigo-tinted badge with a
+ * shield (matching the competition members table); regular users get a neutral
+ * outline. Replaces the old hardcoded `bg-red-100 text-red-800` treatment.
+ */
+export function UserRoleBadge({ isAdmin }: { isAdmin: boolean }) {
+  if (isAdmin) {
+    return (
+      <Badge
+        variant="secondary"
+        className="border-transparent bg-primary/10 text-primary"
+      >
+        <Shield className="mr-1 h-3 w-3" />
+        Admin
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" className="text-muted-foreground">
+      User
+    </Badge>
+  );
+}
+
+/**
+ * Active vs. deactivated account-status pill. Uses the semantic `success`
+ * token for active accounts and a neutral outline for inactive ones, replacing
+ * the old hardcoded green/gray colors.
+ */
+export function UserStatusBadge({ active }: { active: boolean }) {
+  if (active) {
+    return (
+      <Badge
+        variant="secondary"
+        className="border-transparent bg-success-muted text-success-muted-foreground"
+      >
+        Active
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" className="text-muted-foreground">
+      Inactive
+    </Badge>
+  );
+}

--- a/app/admin/users/user-name-cell.tsx
+++ b/app/admin/users/user-name-cell.tsx
@@ -61,7 +61,7 @@ export function UserNameCell({ user }: UserNameCellProps) {
 
   return (
     <div className="px-2">
-      <div className="flex flex-row gap-x-1 sm:gap-x-2 items-center text-sm sm:text-lg">
+      <div className="flex flex-row gap-x-1 sm:gap-x-2 items-center text-sm font-medium">
         <div className="flex items-center gap-x-1 min-w-0 flex-1">
           <Link
             href={`/admin/users/${user.id}`}
@@ -112,9 +112,6 @@ export function UserNameCell({ user }: UserNameCellProps) {
             </Dialog>
           )}
         </div>
-      </div>
-      <div className="text-xs sm:text-sm text-muted-foreground truncate">
-        {user.email}
       </div>
     </div>
   );

--- a/app/admin/users/user-status-cell.tsx
+++ b/app/admin/users/user-status-cell.tsx
@@ -12,11 +12,11 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Badge } from "@/components/ui/badge";
 import { toast } from "@/hooks/use-toast";
 import { setUserActive } from "@/lib/db_actions/users";
 import { handleServerActionResult } from "@/lib/server-action-helpers";
 import { VUser } from "@/types/db_types";
+import { UserStatusBadge } from "./user-badges";
 
 interface UserStatusCellProps {
   user: VUser;
@@ -60,9 +60,7 @@ export function UserStatusCell({ user }: UserStatusCellProps) {
   return (
     <div className="px-2">
       <div className="flex flex-row gap-x-1 sm:gap-x-2 items-center">
-        <Badge variant={isActive ? "default" : "secondary"} className="text-xs">
-          {isActive ? "Active" : "Inactive"}
-        </Badge>
+        <UserStatusBadge active={isActive} />
         <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
           <DialogTrigger asChild>
             <Button

--- a/app/admin/users/users-table.tsx
+++ b/app/admin/users/users-table.tsx
@@ -34,9 +34,6 @@ export default function UsersTable({ data }: { data: VUser[] }) {
     onColumnFiltersChange: setColumnFilters,
     getFilteredRowModel: getFilteredRowModel(),
     state: { sorting, columnFilters },
-    initialState: {
-      columnFilters: [{ id: "resolution", value: [] }],
-    },
   });
 
   return (
@@ -44,12 +41,12 @@ export default function UsersTable({ data }: { data: VUser[] }) {
       <Table>
         <TableHeader className="bg-muted/30">
           {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id} className="border-b">
+            <TableRow key={headerGroup.id} className="border-b hover:bg-transparent">
               {headerGroup.headers.map((header) => {
                 return (
                   <TableHead
                     key={header.id}
-                    className="font-semibold text-muted-foreground text-xs sm:text-sm"
+                    className="font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground"
                   >
                     {header.isPlaceholder
                       ? null


### PR DESCRIPTION
Continues the soft-minimal / Linear-like remodel from #139, taking on the **admin cluster** — the one remaining content item in that issue. These pages were the last big holdout still using shadcn `Card`, centered max-width layouts, and hardcoded Tailwind colors. Done one surface at a time (one commit each).

### What changed

**`/admin` landing index (new)** — Every admin page (and the `admin/competitions` kicker from #144) links its "Admin" label to `/admin`, but no such route existed, so it 404'd. Added a flat, bordered landing index that tiles the sections as `AdminNavCard`s — giving those links a real destination and the area a home.

**Users (list + detail)**
- `Container` + flat bordered surfaces with mono-kicker section/column headers; dropped the `Card` wrappers and centered layouts.
- Replaced hardcoded badge colors (`bg-red-100` / `bg-green-100` / `bg-gray-100`) with shared **`UserRoleBadge` / `UserStatusBadge`** on semantic tokens (indigo admin, success-tinted active), reused across the table and the detail card.
- Detail page: flat identity header + tokenized account-details panel, mono-tabular IDs/dates, no more `shadow-lg` avatar.
- Table: de-duplicated the email (there's already a dedicated Email column), calmed the oversized name cell, and dropped a stray copy-pasted `resolution` column filter.

**Feature flags** — flat widgets instead of `Card`s; feature names render in mono (they're code identifiers), user IDs are mono-tabular, and `FeatureToggle` gets a mono kicker label + an empty state.

**Suggested props** — flat prop cards (hover shifts the border, no drop shadow), a mono-kicker "Notes" label, and a calm empty state in place of the big centered-icon medallion.

**Forecast progress** — swapped the blue/green **gradient** stat cards and `shadow-lg` table card for flat instrument cards; replaced the green/yellow progress bars with a tokenized **`ForecastProgressMeter`** (semantic `success` for complete, neutral fill otherwise); all counts are mono-tabular.

### Storybook
Stories added for the notable presentational components introduced here: `AdminNavCard`, the user badges, `FeatureToggle`, and `ForecastProgressMeter`.

### Verification
- `tsc --noEmit` clean
- `eslint` clean (only the pre-existing TanStack/React-Compiler warning in `users-table`)
- `npm run build-storybook` succeeds

Closes the **Admin** item in #139.

https://claude.ai/code/session_017vgvYE1CFhG7kNPQ8dnTgi

---
_Generated by [Claude Code](https://claude.ai/code/session_017vgvYE1CFhG7kNPQ8dnTgi)_