### PR TITLE
Soft-minimal remodel: audit stragglers (system pages + wrappers) (#139)

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,17 +1,18 @@
 import PageHeading from "@/components/page-heading";
+import { Container } from "@/components/ui/container";
 import { AccountDetails } from "./account-details";
 
 export default async function Page() {
   const idpBaseUrl = process.env.IDP_BASE_URL;
   return (
-    <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
-      <div className="w-full max-w-lg flex flex-col">
+    <main className="py-10 lg:py-14">
+      <Container className="max-w-xl">
         <PageHeading
           title="Account Settings"
           subtitle="Manage your profile and identity provider details."
         />
         <AccountDetails idpBaseUrl={idpBaseUrl} />
-      </div>
+      </Container>
     </main>
   );
 }

--- a/app/competitions/[competitionId]/props/new/page.tsx
+++ b/app/competitions/[competitionId]/props/new/page.tsx
@@ -6,6 +6,7 @@ import ErrorPage from "@/components/pages/error-page";
 import { InaccessiblePage } from "@/components/inaccessible-page";
 import { NewPropForm } from "./new-prop-form";
 import PageHeading from "@/components/page-heading";
+import { Container } from "@/components/ui/container";
 
 export default async function NewPropPage({
   params,
@@ -68,22 +69,24 @@ export default async function NewPropPage({
   const categories = categoriesResult.success ? categoriesResult.data : [];
 
   return (
-    <main className="flex flex-col items-start py-4 px-8 lg:py-8 lg:px-24 w-full max-w-4xl mx-auto">
-      <PageHeading
-        title="New Proposition"
-        breadcrumbs={{
-          Competitions: "/competitions",
-          [competition.name]: `/competitions/${competitionId}`,
-        }}
-        className="mb-6"
-      />
+    <main className="py-10 lg:py-14">
+      <Container className="max-w-3xl">
+        <PageHeading
+          title="New Proposition"
+          breadcrumbs={{
+            Competitions: "/competitions",
+            [competition.name]: `/competitions/${competitionId}`,
+          }}
+          className="mb-6"
+        />
 
-      <NewPropForm
-        competitionId={competitionId}
-        competitionName={competition.name}
-        categories={categories}
-        userId={user.id}
-      />
+        <NewPropForm
+          competitionId={competitionId}
+          competitionName={competition.name}
+          categories={categories}
+          userId={user.id}
+        />
+      </Container>
     </main>
   );
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -2,20 +2,23 @@
 
 import PageHeading from "@/components/page-heading";
 import { Button } from "@/components/ui/button";
+import { Container } from "@/components/ui/container";
 import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
-      <div className="w-full max-w-lg">
-        <PageHeading title="404: Not Found" />
-        <div className="flex flex-col justify-start items-start gap-3">
-          <p>Could not find requested resource</p>
-          <Link href="/">
-            <Button>Return Home</Button>
-          </Link>
+    <main className="flex min-h-[60vh] items-center py-12 lg:py-16">
+      <Container className="max-w-xl">
+        <PageHeading title="Page not found" />
+        <div className="flex flex-col items-start gap-5">
+          <p className="text-sm text-muted-foreground">
+            We couldn&apos;t find the page you were looking for.
+          </p>
+          <Button asChild>
+            <Link href="/">Return home</Link>
+          </Button>
         </div>
-      </div>
+      </Container>
     </main>
   );
 }

--- a/components/inaccessible-page.tsx
+++ b/components/inaccessible-page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import PageHeading from "@/components/page-heading";
 import { Button } from "@/components/ui/button";
+import { Container } from "@/components/ui/container";
 
 export async function InaccessiblePage({
   title,
@@ -10,16 +11,16 @@ export async function InaccessiblePage({
   message: string;
 }) {
   return (
-    <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
-      <div className="w-full max-w-lg">
+    <main className="flex min-h-[60vh] items-center py-12 lg:py-16">
+      <Container className="max-w-xl">
         <PageHeading title={title} />
-        <div className="flex flex-col justify-start items-start gap-3">
-          <p>{message}</p>
-          <Link href="/">
-            <Button>Return Home</Button>
-          </Link>
+        <div className="flex flex-col items-start gap-5">
+          <p className="text-sm text-muted-foreground">{message}</p>
+          <Button asChild>
+            <Link href="/">Return home</Link>
+          </Button>
         </div>
-      </div>
+      </Container>
     </main>
   );
 }

--- a/components/pages/error-page.tsx
+++ b/components/pages/error-page.tsx
@@ -1,4 +1,5 @@
 import PageHeading from "@/components/page-heading";
+import { Container } from "@/components/ui/container";
 
 export default function ErrorPage({
   title,
@@ -8,13 +9,13 @@ export default function ErrorPage({
   children?: React.ReactNode;
 }) {
   return (
-    <main className="flex flex-col items-center justify-between py-8 px-8 lg:py-12 lg:px-24">
-      <div className="w-full max-w-lg">
+    <main className="flex min-h-[60vh] items-center py-12 lg:py-16">
+      <Container className="max-w-xl">
         <PageHeading title={title} />
-        <div className="flex flex-col justify-start items-start gap-3">
+        <div className="flex flex-col items-start gap-3 text-sm text-muted-foreground">
           {children}
         </div>
-      </div>
+      </Container>
     </main>
   );
 }

--- a/components/resolution-select-widget.tsx
+++ b/components/resolution-select-widget.tsx
@@ -60,7 +60,7 @@ export default function ResolutionSelectWidget({
             <Check
               size={20}
               strokeWidth={3}
-              className={resolution === true ? "text-green-500" : ""}
+              className={resolution === true ? "text-success" : ""}
             />
           </button>
         </DialogTrigger>


### PR DESCRIPTION
Continues the soft-minimal remodel from #139, taking the **"Audit stragglers"** item: the shared system pages and a couple of page wrappers that were still on the old centered `lg:px-24` shell, plus one stray hardcoded color. Follows #146 (admin pages).

### What changed

**Shared system / terminal pages** — `ErrorPage`, `InaccessiblePage`, and the `404` not-found page all used the identical old `flex … items-center … lg:px-24` shell. Moved them onto `Container`, vertically centered for a calmer terminal state, with a consistent muted message + "Return home" action. Friendlier 404 copy ("Page not found").

**Page wrappers** — `app/account` and the new-proposition page (`competitions/[id]/props/new`) moved off `lg:px-24` onto `Container`, so they share the app's left edge / gutter like every other remodeled page. (The forms themselves were already done in #143; this is just the outer shell.)

**Tokenize** — `ResolutionSelectWidget`'s resolve check was a hardcoded `text-green-500`; now the semantic `text-success` token, pairing correctly with the existing `text-destructive` reject. Its existing story now reflects the token.

### Scope note
The new-prop page is also where the broken-datepicker bug (#128) lives. I left that out on purpose — it's a layout bug that needs visual verification to fix confidently, so it deserves its own pass rather than riding along in a styling sweep.

### Verification
- `tsc --noEmit` clean
- `eslint` clean
- `npm run build-storybook` succeeds

Closes the **Audit stragglers** item in #139 (the remaining open item there is the optional **Polish pass** — focus-ring states / page-load stagger).

https://claude.ai/code/session_017vgvYE1CFhG7kNPQ8dnTgi

---
_Generated by [Claude Code](https://claude.ai/code/session_017vgvYE1CFhG7kNPQ8dnTgi)_