### PR TITLE
Polish pass: keyboard focus rings + page-load stagger (#139)

### DIFF
--- a/app/admin/admin-nav-card.tsx
+++ b/app/admin/admin-nav-card.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ArrowUpRight } from "lucide-react";
+import { cn, focusRing } from "@/lib/utils";
 
 export interface AdminNavCardProps {
   href: string;
@@ -23,7 +24,10 @@ export function AdminNavCard({
   return (
     <Link
       href={href}
-      className="group flex flex-col gap-4 rounded-lg border bg-card p-5 transition-colors hover:border-foreground/20"
+      className={cn(
+        "group flex flex-col gap-4 rounded-lg border bg-card p-5 transition-colors hover:border-foreground/20",
+        focusRing,
+      )}
     >
       <div className="flex items-start justify-between">
         <span className="flex h-9 w-9 items-center justify-center rounded-md border bg-muted/40 text-muted-foreground transition-colors group-hover:text-foreground">

--- a/app/globals.css
+++ b/app/globals.css
@@ -70,6 +70,7 @@
 
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
+  --animate-fade-in-up: fade-in-up 0.5s ease-out both;
 
   @keyframes accordion-down {
     from {
@@ -88,6 +89,18 @@
 
     to {
       height: 0;
+    }
+  }
+
+  @keyframes fade-in-up {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateY(0);
     }
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,7 +36,7 @@ export default async function Home() {
 
         <div className="grid grid-cols-1 gap-x-8 gap-y-12 md:grid-cols-2 lg:grid-cols-3">
           {/* News */}
-          <section className="flex flex-col gap-4">
+          <section className="flex flex-col gap-4 motion-safe:animate-fade-in-up">
             <SectionHeader kicker="News" />
             <NewsCard icon={MessageCircleWarning} title="New Login System">
               <p>
@@ -70,7 +70,7 @@ export default async function Home() {
           </section>
 
           {/* 2026 Standings */}
-          <section className="flex flex-col gap-4">
+          <section className="flex flex-col gap-4 motion-safe:animate-fade-in-up motion-safe:[animation-delay:120ms]">
             <SectionHeader kicker="2026 Standings" />
             <Suspense fallback={<PanelSkeleton lines={5} />}>
               {/* Competition ID 6 = 2026 */}
@@ -79,7 +79,7 @@ export default async function Home() {
           </section>
 
           {/* Recently Resolved */}
-          <section className="flex flex-col gap-4">
+          <section className="flex flex-col gap-4 motion-safe:animate-fade-in-up motion-safe:[animation-delay:240ms]">
             <SectionHeader kicker="Recently Resolved" />
             <Suspense fallback={<PanelSkeleton lines={3} />}>
               <RecentlyResolved userId={user.id} />

--- a/app/props/[propId]/forecasts-list.tsx
+++ b/app/props/[propId]/forecasts-list.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { ChevronDown } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, focusRing } from "@/lib/utils";
 import { getProbabilityColors } from "@/lib/forecast-colors";
 import type { VForecast } from "@/types/db_types";
 
@@ -98,7 +98,10 @@ export default function ForecastsList({
         </span>
         <button
           onClick={() => setSortOrder((s) => (s === "desc" ? "asc" : "desc"))}
-          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          className={cn(
+            "flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+            focusRing,
+          )}
         >
           <ChevronDown
             className={cn(

--- a/app/props/[propId]/prop-page-header.tsx
+++ b/app/props/[propId]/prop-page-header.tsx
@@ -11,6 +11,7 @@ import { PropEditDialog } from "@/components/dialogs/prop-edit-dialog";
 import { MarkdownRenderer } from "@/components/markdown";
 import { PropStatusBadge } from "@/components/ui/prop-status-badge";
 import { getPropStatusFromProp } from "@/lib/prop-status";
+import { cn, focusRing } from "@/lib/utils";
 
 interface PropPageHeaderProps {
   prop: VProp;
@@ -32,7 +33,10 @@ export default function PropPageHeader({
       {/* Back button */}
       <button
         onClick={() => router.back()}
-        className="text-sm text-muted-foreground hover:text-foreground flex items-center gap-1 mb-4"
+        className={cn(
+          "mb-4 flex items-center gap-1 rounded-sm text-sm text-muted-foreground hover:text-foreground",
+          focusRing,
+        )}
       >
         <ChevronLeft className="w-4 h-4" />
         Back

--- a/components/competition-dashboard/competition-tabs.tsx
+++ b/components/competition-dashboard/competition-tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { cn, focusRing } from "@/lib/utils";
 
 interface TabButtonProps {
   active: boolean;
@@ -14,7 +14,8 @@ function TabButton({ active, children, onClick, count }: TabButtonProps) {
     <button
       onClick={onClick}
       className={cn(
-        "flex items-center gap-1.5 border-b-2 px-3 py-2.5 text-sm font-medium transition-colors",
+        "flex items-center gap-1.5 rounded-sm border-b-2 px-3 py-2.5 text-sm font-medium transition-colors",
+        focusRing,
         active
           ? "border-primary text-foreground"
           : "border-transparent text-muted-foreground hover:text-foreground",

--- a/components/competition-dashboard/stat-cards.tsx
+++ b/components/competition-dashboard/stat-cards.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { cn, focusRing } from "@/lib/utils";
 import type { DashboardTab } from "./competition-tabs";
 
 interface StatCardProps {
@@ -25,7 +25,7 @@ export function StatCard({
       onClick={onClick}
       className={cn(
         "flex flex-col gap-1.5 rounded-lg border bg-card p-4 text-left transition-colors",
-        onClick && "cursor-pointer hover:border-foreground/20",
+        onClick && cn("cursor-pointer hover:border-foreground/20", focusRing),
         active && "border-primary/60 bg-primary/[0.03]",
       )}
     >

--- a/components/competition-dashboard/upcoming-deadlines.tsx
+++ b/components/competition-dashboard/upcoming-deadlines.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { cn } from "@/lib/utils";
+import { cn, focusRing } from "@/lib/utils";
 import type { UpcomingDeadline } from "@/lib/db_actions/competition-stats";
 import { getBrowserTimezone } from "@/hooks/getBrowserTimezone";
 import { formatDate } from "@/lib/time-utils";
@@ -128,7 +128,10 @@ export function UpcomingDeadlines({
         {onViewAll && (
           <button
             onClick={onViewAll}
-            className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+            className={cn(
+              "rounded-sm text-xs font-medium text-muted-foreground transition-colors hover:text-foreground",
+              focusRing,
+            )}
           >
             View all →
           </button>

--- a/components/forecast-card/editable-forecast-card.tsx
+++ b/components/forecast-card/editable-forecast-card.tsx
@@ -12,7 +12,7 @@ import { createForecast, updateForecast } from "@/lib/db_actions";
 import { useServerAction } from "@/hooks/use-server-action";
 import { PropEditDialog } from "@/components/dialogs/prop-edit-dialog";
 import { Spinner } from "@/components/ui/spinner";
-import { cn } from "@/lib/utils";
+import { cn, focusRing } from "@/lib/utils";
 
 interface EditableForecastCardProps {
   prop: PropWithUserForecast;
@@ -152,7 +152,10 @@ export function EditableForecastCard({
                 type="button"
                 onClick={() => setIsEditDialogOpen(true)}
                 aria-label="Edit prop"
-                className="shrink-0 text-muted-foreground hover:text-foreground"
+                className={cn(
+                  "shrink-0 rounded-sm text-muted-foreground hover:text-foreground",
+                  focusRing,
+                )}
               >
                 <Pencil className="h-5 w-5" />
               </button>

--- a/components/landing/icon-link-button.tsx
+++ b/components/landing/icon-link-button.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { ArrowRight, LucideIcon } from "lucide-react";
+import { cn, focusRing } from "@/lib/utils";
 
 interface IconLinkButtonProps {
   icon: LucideIcon;
@@ -15,7 +16,10 @@ export default function IconLinkButton({
   return (
     <Link
       href={href}
-      className="group flex items-center justify-between gap-2 rounded-md border bg-card px-3 py-2 text-sm font-medium transition-colors hover:bg-muted"
+      className={cn(
+        "group flex items-center justify-between gap-2 rounded-md border bg-card px-3 py-2 text-sm font-medium transition-colors hover:bg-muted",
+        focusRing,
+      )}
     >
       <span className="flex min-w-0 items-center gap-2">
         <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />

--- a/components/landing/mini-leaderboard.tsx
+++ b/components/landing/mini-leaderboard.tsx
@@ -1,7 +1,7 @@
 import { getCompetitionScores } from "@/lib/db_actions";
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, focusRing } from "@/lib/utils";
 
 interface MiniLeaderboardProps {
   competitionId: number;
@@ -39,7 +39,10 @@ export default async function MiniLeaderboard({
   return (
     <Link
       href={`/competitions/${competitionId}?tab=leaderboard`}
-      className="group block rounded-lg border bg-card p-2 transition-colors hover:border-foreground/20"
+      className={cn(
+        "group block rounded-lg border bg-card p-2 transition-colors hover:border-foreground/20",
+        focusRing,
+      )}
     >
       <div className="flex items-center justify-between px-3 pb-2 pt-1.5 font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
         <span>Forecaster</span>

--- a/components/landing/resolved-prop-card.tsx
+++ b/components/landing/resolved-prop-card.tsx
@@ -1,7 +1,7 @@
 import { Check, X } from "lucide-react";
 import Link from "next/link";
 import { LocalDate } from "@/components/local-date";
-import { cn } from "@/lib/utils";
+import { cn, focusRing } from "@/lib/utils";
 
 interface ResolvedPropCardProps {
   propId: number;
@@ -23,7 +23,10 @@ export default function ResolvedPropCard({
   return (
     <Link
       href={`/props/${propId}`}
-      className="block rounded-lg border bg-card p-4 transition-colors hover:border-foreground/20"
+      className={cn(
+        "block rounded-lg border bg-card p-4 transition-colors hover:border-foreground/20",
+        focusRing,
+      )}
     >
       <p
         className="text-sm font-medium leading-snug text-foreground line-clamp-2"

--- a/components/resolution-select-widget.tsx
+++ b/components/resolution-select-widget.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Check, X } from "lucide-react";
+import { cn, focusRing } from "@/lib/utils";
 
 export default function ResolutionSelectWidget({
   resolution,
@@ -32,11 +33,12 @@ export default function ResolutionSelectWidget({
   // unresolve it. Otherwise, we want to set it to the last clicked value.
   const resolutionToSet = lastClicked === resolution ? undefined : lastClicked;
   const buttonClasses = (selected: boolean) =>
-    `${
-      size == "lg" ? "px-4 py-1.5" : "px-2 py-1"
-    } rounded-full transition-colors duration-200 hover:bg-accent hover:text-accent-foreground ${
-      selected ? "bg-background" : "text-muted-foreground"
-    }`;
+    cn(
+      size == "lg" ? "px-4 py-1.5" : "px-2 py-1",
+      "rounded-full transition-colors duration-200 hover:bg-accent hover:text-accent-foreground",
+      focusRing,
+      selected ? "bg-background" : "text-muted-foreground",
+    );
   return (
     <div className="inline-flex justify-between items-center bg-secondary rounded-full p-1 w-fit">
       <Dialog open={dialogIsOpen} onOpenChange={setDialogIsOpen}>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,12 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Shared keyboard focus indicator for custom interactive elements (plain
+ * `<button>`s, clickable cards/links) that don't go through the `Button`
+ * primitive. Token-based and `focus-visible`-only, so it shows for keyboard
+ * users without ringing on mouse clicks.
+ */
+export const focusRing =
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";


### PR DESCRIPTION
The final **"Polish pass"** item from #139. Follows #146 (admin pages) and #147 (audit stragglers).

### 1. Consistent keyboard focus rings
Several custom interactive elements don't go through the `Button` primitive and so had **no visible focus state** — a real keyboard-accessibility gap. Added a shared `focusRing` helper in `lib/utils.ts` (token-based, `focus-visible`-only so it shows for keyboard users without ringing on mouse clicks) and applied it to:

- competition dashboard **tabs** and clickable **stat cards**
- the **admin nav cards** (from #146)
- the landing **link button / mini-leaderboard / resolved-prop** cards
- the prop **back button** + **forecasts sort** toggle
- the **editable-forecast edit** button and **upcoming-deadlines "view all"**
- the **resolve / unresolve** toggle in `ResolutionSelectWidget`

One source of truth, so the focus style stays consistent and is easy to tweak later.

### 2. Subtle page-load stagger
Added a `fade-in-up` keyframe/animation token and staggered the home dashboard's three sections (News / Standings / Recently Resolved) by 120ms each. **Gated behind `motion-safe`**, so it's a no-op under `prefers-reduced-motion`.

### Verification
- `tsc --noEmit` clean, `eslint` clean
- `npm run build-storybook` succeeds; confirmed Tailwind emits the new utilities (`fade-in-up`, `ring-offset-2`, `ring-offset-background`) from the shared constant + theme token
- No new components, so no new stories — `focusRing` is a cross-cutting utility, not a component

With this, #139 is down to just the optional "subtle backdrop texture" idea and the separately-tracked datepicker bug (#128).

https://claude.ai/code/session_017vgvYE1CFhG7kNPQ8dnTgi

---
_Generated by [Claude Code](https://claude.ai/code/session_017vgvYE1CFhG7kNPQ8dnTgi)_