### PR TITLE
Add /standalone/calibration page (#54)

### DIFF
--- a/app/standalone/calibration/calibration-chart.stories.tsx
+++ b/app/standalone/calibration/calibration-chart.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CalibrationChart } from "./calibration-chart";
+import type { CalibrationBucket } from "@/lib/calibration";
+
+function bucket(
+  i: number,
+  count: number,
+  observedFrequency: number,
+): CalibrationBucket {
+  return {
+    binStart: i / 10,
+    binEnd: (i + 1) / 10,
+    count,
+    meanPredicted: (i + 0.5) / 10,
+    observedFrequency,
+  };
+}
+
+// Observed ≈ predicted — points hug the diagonal.
+const WELL_CALIBRATED: CalibrationBucket[] = [
+  bucket(0, 12, 0.04),
+  bucket(2, 18, 0.27),
+  bucket(4, 22, 0.48),
+  bucket(6, 16, 0.63),
+  bucket(8, 14, 0.82),
+  bucket(9, 9, 0.96),
+];
+
+// Confident predictions that don't pan out — points fall below the diagonal at
+// the high end and above it at the low end.
+const OVERCONFIDENT: CalibrationBucket[] = [
+  bucket(0, 10, 0.18),
+  bucket(1, 14, 0.26),
+  bucket(7, 15, 0.52),
+  bucket(8, 20, 0.55),
+  bucket(9, 24, 0.6),
+];
+
+const meta = {
+  title: "Calibration/CalibrationChart",
+  component: CalibrationChart,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="w-[28rem] rounded-lg border bg-card p-5">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CalibrationChart>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WellCalibrated: Story = {
+  args: { buckets: WELL_CALIBRATED },
+};
+
+export const Overconfident: Story = {
+  args: { buckets: OVERCONFIDENT },
+};
+
+export const Sparse: Story = {
+  args: { buckets: [bucket(3, 2, 0.5), bucket(7, 1, 1)] },
+};
+
+export const Empty: Story = {
+  args: { buckets: [] },
+};

--- a/app/standalone/calibration/calibration-chart.tsx
+++ b/app/standalone/calibration/calibration-chart.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import {
+  CartesianGrid,
+  ReferenceLine,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ZAxis,
+} from "recharts";
+import { ChartContainer, type ChartConfig } from "@/components/ui/chart";
+import type { CalibrationBucket } from "@/lib/calibration";
+
+const chartConfig = {} satisfies ChartConfig;
+
+interface CalibrationPoint {
+  /** Mean predicted probability, 0–100. */
+  predicted: number;
+  /** Observed YES frequency, 0–100. */
+  observed: number;
+  count: number;
+  binStart: number;
+  binEnd: number;
+}
+
+/**
+ * Reliability diagram: each point is a probability bucket, plotted as mean
+ * predicted probability (x) vs. observed YES frequency (y), sized by how many
+ * forecasts fell in the bucket. The dashed diagonal is perfect calibration —
+ * points above it mean the events happened more often than predicted, below
+ * means less often.
+ */
+export function CalibrationChart({ buckets }: { buckets: CalibrationBucket[] }) {
+  const data: CalibrationPoint[] = buckets.map((b) => ({
+    predicted: b.meanPredicted * 100,
+    observed: b.observedFrequency * 100,
+    count: b.count,
+    binStart: b.binStart,
+    binEnd: b.binEnd,
+  }));
+
+  if (data.length === 0) {
+    return (
+      <div className="flex aspect-square w-full max-w-md items-center justify-center text-sm text-muted-foreground">
+        No resolved forecasts to plot.
+      </div>
+    );
+  }
+
+  return (
+    <ChartContainer
+      config={chartConfig}
+      className="mx-auto aspect-square w-full max-w-md"
+    >
+      <ScatterChart margin={{ top: 12, right: 16, bottom: 28, left: 12 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+        <XAxis
+          type="number"
+          dataKey="predicted"
+          domain={[0, 100]}
+          ticks={[0, 25, 50, 75, 100]}
+          tickLine={false}
+          axisLine={false}
+          tick={{ fontSize: 11 }}
+          tickFormatter={(v) => `${v}%`}
+          label={{
+            value: "Predicted probability",
+            position: "bottom",
+            offset: 10,
+            fontSize: 11,
+          }}
+        />
+        <YAxis
+          type="number"
+          dataKey="observed"
+          domain={[0, 100]}
+          ticks={[0, 25, 50, 75, 100]}
+          tickLine={false}
+          axisLine={false}
+          tick={{ fontSize: 11 }}
+          tickFormatter={(v) => `${v}%`}
+          label={{
+            value: "Observed frequency",
+            angle: -90,
+            position: "left",
+            offset: 0,
+            fontSize: 11,
+          }}
+        />
+        <ZAxis type="number" dataKey="count" range={[60, 500]} />
+        {/* Perfect-calibration diagonal */}
+        <ReferenceLine
+          segment={[
+            { x: 0, y: 0 },
+            { x: 100, y: 100 },
+          ]}
+          stroke="var(--muted-foreground)"
+          strokeDasharray="4 4"
+          ifOverflow="hidden"
+        />
+        <Tooltip cursor={false} content={<CalibrationTooltip />} />
+        <Scatter
+          data={data}
+          fill="var(--primary)"
+          fillOpacity={0.75}
+          stroke="var(--primary)"
+        />
+      </ScatterChart>
+    </ChartContainer>
+  );
+}
+
+function CalibrationTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload: CalibrationPoint }>;
+}) {
+  if (!active || !payload?.length) return null;
+  const p = payload[0].payload;
+  return (
+    <div className="grid min-w-40 gap-1.5 rounded-lg border bg-popover px-2.5 py-2 text-xs text-popover-foreground shadow-xl">
+      <span className="font-medium">
+        {Math.round(p.binStart * 100)}–{Math.round(p.binEnd * 100)}% bucket
+      </span>
+      <div className="grid grid-cols-2 gap-x-3">
+        <span className="text-muted-foreground">Forecasts</span>
+        <span className="text-right font-mono tabular-nums">{p.count}</span>
+        <span className="text-muted-foreground">Avg predicted</span>
+        <span className="text-right font-mono tabular-nums">
+          {p.predicted.toFixed(0)}%
+        </span>
+        <span className="text-muted-foreground">Resolved yes</span>
+        <span className="text-right font-mono tabular-nums">
+          {p.observed.toFixed(0)}%
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/app/standalone/calibration/calibration-view.tsx
+++ b/app/standalone/calibration/calibration-view.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  computeCalibration,
+  type CalibrationBucket,
+  type ResolvedForecast,
+} from "@/lib/calibration";
+import { CalibrationChart } from "./calibration-chart";
+
+/** The per-forecast data the page hands to the view (already reduced + resolved). */
+export interface CalibrationForecast {
+  forecast: number;
+  resolvedYes: boolean;
+  /** Forecast creation time, as a ms timestamp (serializable across the RSC boundary). */
+  createdAt: number;
+  competitionId: number | null;
+  competitionName: string | null;
+}
+
+type Period = "all" | "year" | "90d" | "30d";
+
+const PERIOD_LABELS: Record<Period, string> = {
+  all: "All time",
+  year: "Last 12 months",
+  "90d": "Last 90 days",
+  "30d": "Last 30 days",
+};
+
+const PERIOD_MS: Record<Period, number> = {
+  all: Infinity,
+  year: 365 * 24 * 60 * 60 * 1000,
+  "90d": 90 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+};
+
+export function CalibrationView({
+  forecasts,
+}: {
+  forecasts: CalibrationForecast[];
+}) {
+  const [competition, setCompetition] = useState("all");
+  const [period, setPeriod] = useState<Period>("all");
+  // The period cutoff is computed in the change handler (an event, where reading
+  // the clock is allowed) and stored, so render stays pure.
+  const [cutoff, setCutoff] = useState(-Infinity);
+
+  const handlePeriodChange = (value: string) => {
+    const next = value as Period;
+    setPeriod(next);
+    setCutoff(next === "all" ? -Infinity : Date.now() - PERIOD_MS[next]);
+  };
+
+  // Distinct named competitions present in the data, for the filter.
+  const competitions = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const f of forecasts) {
+      if (f.competitionId !== null && f.competitionName !== null) {
+        map.set(f.competitionId, f.competitionName);
+      }
+    }
+    return Array.from(map, ([id, name]) => ({ id, name })).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+  }, [forecasts]);
+
+  const filtered = useMemo(() => {
+    return forecasts.filter((f) => {
+      if (competition !== "all" && String(f.competitionId) !== competition) {
+        return false;
+      }
+      return f.createdAt >= cutoff;
+    });
+  }, [forecasts, competition, cutoff]);
+
+  const result = useMemo(() => {
+    const resolved: ResolvedForecast[] = filtered.map((f) => ({
+      forecast: f.forecast,
+      resolvedYes: f.resolvedYes,
+    }));
+    return computeCalibration(resolved);
+  }, [filtered]);
+
+  return (
+    <div className="space-y-6">
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Select value={competition} onValueChange={setCompetition}>
+          <SelectTrigger className="w-[200px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All competitions</SelectItem>
+            {competitions.map((c) => (
+              <SelectItem key={c.id} value={String(c.id)}>
+                {c.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={period} onValueChange={handlePeriodChange}>
+          <SelectTrigger className="w-[180px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {(Object.keys(PERIOD_LABELS) as Period[]).map((p) => (
+              <SelectItem key={p} value={p}>
+                {PERIOD_LABELS[p]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {result.total === 0 ? (
+        <div className="rounded-lg border bg-card p-10 text-center">
+          <p className="text-sm font-medium text-foreground">
+            No resolved forecasts
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Once props you forecasted are resolved, your calibration will show
+            up here.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Summary */}
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+            <StatCard label="Resolved forecasts" value={result.total} />
+            <StatCard
+              label="Brier score"
+              value={result.brierScore!.toFixed(3)}
+              hint="Lower is better"
+            />
+            <StatCard
+              label="Buckets"
+              value={result.buckets.length}
+              hint="Non-empty 10% bins"
+            />
+          </div>
+
+          {/* Reliability diagram */}
+          <div className="rounded-lg border bg-card p-5">
+            <h2 className="mb-1 font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+              Reliability diagram
+            </h2>
+            <p className="mb-4 text-sm text-muted-foreground">
+              Points on the dashed line are perfectly calibrated. Above the line,
+              events happened more often than you predicted; below, less often.
+              Point size reflects how many forecasts fell in each bucket.
+            </p>
+            <CalibrationChart buckets={result.buckets} />
+          </div>
+
+          {/* Per-bucket breakdown */}
+          <BucketsTable buckets={result.buckets} />
+        </>
+      )}
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: number | string;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-1.5 font-mono text-2xl font-semibold tabular-nums tracking-tight text-foreground">
+        {value}
+      </div>
+      {hint && <div className="mt-0.5 text-xs text-muted-foreground">{hint}</div>}
+    </div>
+  );
+}
+
+const KICKER =
+  "font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground";
+
+function BucketsTable({ buckets }: { buckets: CalibrationBucket[] }) {
+  return (
+    <section className="overflow-hidden rounded-lg border bg-card">
+      <div className="border-b px-4 py-3 sm:px-5">
+        <span className="font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+          By bucket
+        </span>
+      </div>
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader className="bg-muted/30">
+            <TableRow className="border-b hover:bg-transparent">
+              <TableHead className={KICKER}>Predicted range</TableHead>
+              <TableHead className={`${KICKER} text-right`}>Forecasts</TableHead>
+              <TableHead className={`${KICKER} text-right`}>
+                Avg predicted
+              </TableHead>
+              <TableHead className={`${KICKER} text-right`}>
+                Resolved yes
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {buckets.map((b) => (
+              <TableRow key={b.binStart} className="hover:bg-muted/30">
+                <TableCell className="py-3 font-mono text-sm tabular-nums">
+                  {Math.round(b.binStart * 100)}–{Math.round(b.binEnd * 100)}%
+                </TableCell>
+                <TableCell className="py-3 text-right font-mono text-sm tabular-nums text-muted-foreground">
+                  {b.count}
+                </TableCell>
+                <TableCell className="py-3 text-right font-mono text-sm tabular-nums">
+                  {(b.meanPredicted * 100).toFixed(0)}%
+                </TableCell>
+                <TableCell className="py-3 text-right font-mono text-sm tabular-nums">
+                  {(b.observedFrequency * 100).toFixed(0)}%
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </section>
+  );
+}

--- a/app/standalone/calibration/page.tsx
+++ b/app/standalone/calibration/page.tsx
@@ -1,0 +1,43 @@
+import { getUserFromCookies } from "@/lib/get-user";
+import { getForecasts } from "@/lib/db_actions";
+import { InaccessiblePage } from "@/components/inaccessible-page";
+import { Container } from "@/components/ui/container";
+import PageHeading from "@/components/page-heading";
+import { CalibrationView, type CalibrationForecast } from "./calibration-view";
+
+export default async function CalibrationPage() {
+  const user = await getUserFromCookies();
+  if (!user) {
+    return (
+      <InaccessiblePage
+        title="Not logged in"
+        message="You must be logged in to see your calibration."
+      />
+    );
+  }
+
+  const result = await getForecasts({ userId: user.id });
+  const forecasts: CalibrationForecast[] = result.success
+    ? result.data
+        .filter((f) => f.resolution !== null)
+        .map((f) => ({
+          forecast: f.forecast,
+          resolvedYes: f.resolution === true,
+          createdAt: new Date(f.forecast_created_at).getTime(),
+          competitionId: f.competition_id,
+          competitionName: f.competition_name,
+        }))
+    : [];
+
+  return (
+    <main className="py-10 lg:py-14">
+      <Container className="max-w-3xl">
+        <PageHeading
+          title="Calibration"
+          subtitle="How your forecasts have matched reality — bucketed by predicted probability and compared against what actually happened."
+        />
+        <CalibrationView forecasts={forecasts} />
+      </Container>
+    </main>
+  );
+}

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -18,6 +18,7 @@ import {
   Flag,
   Medal,
   MessageCircle,
+  Target,
   Users,
   Menu,
 } from "lucide-react";
@@ -98,6 +99,14 @@ export default function NavBar() {
     links.push({
       label: "Competitions",
       sections,
+    });
+  }
+
+  if (user) {
+    links.push({
+      href: "/standalone/calibration",
+      label: "Calibration",
+      icon: <Target size={16} />,
     });
   }
 

--- a/lib/calibration.test.ts
+++ b/lib/calibration.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeCalibration,
+  toResolvedForecasts,
+  type ResolvedForecast,
+} from "./calibration";
+import type { VForecast } from "@/types/db_types";
+
+describe("toResolvedForecasts", () => {
+  it("drops unresolved forecasts and reduces to the calibration shape", () => {
+    const forecasts = [
+      { forecast: 0.8, resolution: true },
+      { forecast: 0.3, resolution: false },
+      { forecast: 0.5, resolution: null },
+    ] as VForecast[];
+
+    expect(toResolvedForecasts(forecasts)).toEqual([
+      { forecast: 0.8, resolvedYes: true },
+      { forecast: 0.3, resolvedYes: false },
+    ]);
+  });
+});
+
+describe("computeCalibration", () => {
+  it("returns an empty result for no forecasts", () => {
+    expect(computeCalibration([])).toEqual({
+      buckets: [],
+      total: 0,
+      brierScore: null,
+    });
+  });
+
+  it("omits empty bins and orders buckets low → high", () => {
+    const forecasts: ResolvedForecast[] = [
+      { forecast: 0.05, resolvedYes: false },
+      { forecast: 0.95, resolvedYes: true },
+    ];
+    const { buckets, total } = computeCalibration(forecasts);
+    expect(total).toBe(2);
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0].binStart).toBe(0);
+    expect(buckets[1].binStart).toBeCloseTo(0.9);
+  });
+
+  it("computes mean predicted and observed frequency per bin", () => {
+    // Four forecasts in the 0.7–0.8 bin; 3 of 4 resolved YES.
+    const forecasts: ResolvedForecast[] = [
+      { forecast: 0.7, resolvedYes: true },
+      { forecast: 0.72, resolvedYes: true },
+      { forecast: 0.74, resolvedYes: true },
+      { forecast: 0.76, resolvedYes: false },
+    ];
+    const { buckets } = computeCalibration(forecasts);
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].count).toBe(4);
+    expect(buckets[0].meanPredicted).toBeCloseTo(0.73);
+    expect(buckets[0].observedFrequency).toBe(0.75);
+  });
+
+  it("puts a forecast of exactly 1 in the final bin", () => {
+    const { buckets } = computeCalibration([
+      { forecast: 1, resolvedYes: true },
+    ]);
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].binStart).toBeCloseTo(0.9);
+    expect(buckets[0].binEnd).toBe(1);
+  });
+
+  it("computes the mean Brier score", () => {
+    // Perfect predictions → Brier 0.
+    expect(
+      computeCalibration([
+        { forecast: 1, resolvedYes: true },
+        { forecast: 0, resolvedYes: false },
+      ]).brierScore,
+    ).toBe(0);
+
+    // A single 0.5 prediction → (0.5 - 1)^2 = 0.25.
+    expect(
+      computeCalibration([{ forecast: 0.5, resolvedYes: true }]).brierScore,
+    ).toBeCloseTo(0.25);
+  });
+
+  it("respects a custom bin count", () => {
+    const forecasts: ResolvedForecast[] = [
+      { forecast: 0.2, resolvedYes: false },
+      { forecast: 0.8, resolvedYes: true },
+    ];
+    // With 2 bins the split is at 0.5, so two separate buckets.
+    const { buckets } = computeCalibration(forecasts, 2);
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0].binEnd).toBe(0.5);
+  });
+});

--- a/lib/calibration.ts
+++ b/lib/calibration.ts
@@ -1,0 +1,102 @@
+import type { VForecast } from "@/types/db_types";
+
+/**
+ * Calibration math for the standalone calibration page.
+ *
+ * A forecaster is *well calibrated* when, across the forecasts where they said
+ * "X%", the event actually happened about X% of the time. We measure that by
+ * bucketing resolved forecasts by their predicted probability and, for each
+ * bucket, comparing the mean predicted probability to the observed frequency of
+ * YES outcomes. Plotted, a perfectly calibrated forecaster sits on the y = x
+ * diagonal. (See FiveThirtyEight, "When We Say 70 Percent, It Really Means 70
+ * Percent".)
+ *
+ * Pure and dependency-free so it can be unit tested and run on either side of
+ * the server/client boundary.
+ */
+
+/** A resolved forecast reduced to the two numbers calibration needs. */
+export interface ResolvedForecast {
+  /** Predicted probability of YES, in [0, 1]. */
+  forecast: number;
+  /** Whether the prop actually resolved YES. */
+  resolvedYes: boolean;
+}
+
+export interface CalibrationBucket {
+  /** Bin lower bound (inclusive), in [0, 1]. */
+  binStart: number;
+  /** Bin upper bound (exclusive, except the final bin which is inclusive). */
+  binEnd: number;
+  /** Number of resolved forecasts that fell in this bin. */
+  count: number;
+  /** Mean predicted probability of the forecasts in this bin (0–1). */
+  meanPredicted: number;
+  /** Fraction of those forecasts that resolved YES (0–1). */
+  observedFrequency: number;
+}
+
+export interface CalibrationResult {
+  /** One entry per non-empty bin, ordered low → high predicted probability. */
+  buckets: CalibrationBucket[];
+  /** Total resolved forecasts considered. */
+  total: number;
+  /**
+   * Mean Brier score across the resolved forecasts (0–1, lower is better), or
+   * `null` when there are no forecasts.
+   */
+  brierScore: number | null;
+}
+
+/** Keep only resolved forecasts and reduce them to the calibration shape. */
+export function toResolvedForecasts(forecasts: VForecast[]): ResolvedForecast[] {
+  return forecasts
+    .filter((f) => f.resolution !== null)
+    .map((f) => ({ forecast: f.forecast, resolvedYes: f.resolution === true }));
+}
+
+const clamp01 = (n: number) => Math.min(Math.max(n, 0), 1);
+
+/**
+ * Bucket resolved forecasts into `binCount` equal-width bins and compute the
+ * mean predicted probability, observed YES frequency, and overall Brier score.
+ */
+export function computeCalibration(
+  forecasts: ResolvedForecast[],
+  binCount = 10,
+): CalibrationResult {
+  const total = forecasts.length;
+  if (total === 0) {
+    return { buckets: [], total: 0, brierScore: null };
+  }
+
+  const bins = Array.from({ length: binCount }, () => ({
+    count: 0,
+    predictedSum: 0,
+    yesCount: 0,
+  }));
+  let brierSum = 0;
+
+  for (const f of forecasts) {
+    const p = clamp01(f.forecast);
+    const outcome = f.resolvedYes ? 1 : 0;
+    brierSum += (p - outcome) ** 2;
+    // The top edge (p === 1) belongs to the last bin.
+    const index = Math.min(Math.floor(p * binCount), binCount - 1);
+    bins[index].count += 1;
+    bins[index].predictedSum += p;
+    bins[index].yesCount += outcome;
+  }
+
+  const buckets: CalibrationBucket[] = bins
+    .map((bin, i) => ({
+      binStart: i / binCount,
+      binEnd: (i + 1) / binCount,
+      count: bin.count,
+      meanPredicted: bin.count > 0 ? bin.predictedSum / bin.count : 0,
+      observedFrequency: bin.count > 0 ? bin.yesCount / bin.count : 0,
+    }))
+    .filter((bucket) => bucket.count > 0);
+
+  return { buckets, total, brierScore: brierSum / total };
+}


### PR DESCRIPTION
Closes #54. A personal **calibration** page so a forecaster can see how well their predicted probabilities have matched reality.

### What it does
Buckets the user's *resolved* forecasts by predicted probability (10% bins) and, for each bucket, compares the **mean predicted probability** to the **observed frequency** of YES outcomes — the reliability diagram from the FiveThirtyEight piece the issue links. Points on the dashed diagonal are perfectly calibrated; above = events happened more often than predicted, below = less often. Point size encodes how many forecasts landed in each bucket.

Also shows summary stats (resolved-forecast count, **Brier score**), a per-bucket table, and **competition / time-period filters**. Linked from the navbar (logged-in users).

### Structure
- **`lib/calibration.ts`** — pure, dependency-free `computeCalibration` / `toResolvedForecasts` (bucketing + Brier). **Unit-tested** (`lib/calibration.test.ts`, 7 cases).
- **`calibration-chart.tsx`** — presentational Recharts reliability diagram (a client leaf; mirrors the existing prop-consensus chart pattern). **Story added** with well-calibrated / overconfident / sparse / empty fixtures.
- **`calibration-view.tsx`** — client orchestrator: filters + compute + summary + chart + table. (The period cutoff is computed in the change handler, not during render, to satisfy the React-Compiler purity lint.)
- **`page.tsx`** — server component; fetches the current user's forecasts (`getForecasts`, RLS) and reduces them to the calibration shape.

### Design
Follows the soft-minimal language from #139 — flat bordered surfaces, mono-kicker headers, mono-tabular numerics, `Container`, semantic tokens.

### Notes / scope
- **v1 defaults** I picked (happy to adjust): 10% deciles, per-user across all competitions, rolling time windows (all / 12mo / 90d / 30d). Brier computed directly from forecast + outcome.
- **Verification:** `tsc` clean, `eslint` clean, the calibration unit tests pass, and `build-storybook` succeeds. I could **not** run the live page here (no local Postgres in this environment), so the page's data wiring is validated by types/lint rather than a live render — worth a quick local look before merge.

https://claude.ai/code/session_017vgvYE1CFhG7kNPQ8dnTgi

---
_Generated by [Claude Code](https://claude.ai/code/session_017vgvYE1CFhG7kNPQ8dnTgi)_