### PR TITLE
Drop misleading external-link icons from same-tab links

### DIFF
--- a/app/admin/competitions/competition-row.tsx
+++ b/app/admin/competitions/competition-row.tsx
@@ -2,7 +2,7 @@
 
 import { Competition } from "@/types/db_types";
 import Link from "next/link";
-import { Edit, ExternalLink } from "lucide-react";
+import { Edit } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -41,20 +41,15 @@ export default function CompetitionRow({
     <div className="flex items-center justify-between p-4 transition-colors hover:bg-muted/40">
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-3 mb-2">
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 min-w-0">
             <h3 className="text-lg font-semibold truncate">
               <Link
-                href={`/competitions/${competition.id}/forecasts`}
+                href={`/competitions/${competition.id}`}
                 className="hover:text-primary transition-colors"
               >
                 {competition.name}
               </Link>
             </h3>
-            <Button variant="ghost" size="icon" className="h-8 w-8" asChild>
-              <Link href={`/competitions/${competition.id}`}>
-                <ExternalLink className="h-4 w-4" />
-              </Link>
-            </Button>
           </div>
           <div className="flex items-center gap-1 ml-auto">
             <Dialog open={open} onOpenChange={setOpen}>

--- a/app/admin/users/user-name-cell.tsx
+++ b/app/admin/users/user-name-cell.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { ExternalLink, User } from "lucide-react";
+import { User } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -65,10 +65,9 @@ export function UserNameCell({ user }: UserNameCellProps) {
         <div className="flex items-center gap-x-1 min-w-0 flex-1">
           <Link
             href={`/admin/users/${user.id}`}
-            className="flex items-center gap-x-1 hover:text-primary transition-colors min-w-0"
+            className="flex items-center hover:text-primary transition-colors min-w-0"
           >
             <span className="truncate">{name}</span>
-            <ExternalLink className="h-3 w-3 flex-shrink-0" />
           </Link>
           {/* Impersonate button - only show for non-admin, active users */}
           {!user.is_admin && !user.deactivated_at && (

--- a/app/competitions/[competitionId]/scores/user/[userId]/components/score-table-parts.tsx
+++ b/app/competitions/[competitionId]/scores/user/[userId]/components/score-table-parts.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { ExternalLink } from "lucide-react";
 import {
   TableCell,
   TableHead,
@@ -51,17 +50,12 @@ export function ForecastScoreRow({
   return (
     <TableRow>
       <TableCell className="max-w-md">
-        <div className="flex items-center gap-2">
-          <div className="flex-1 truncate text-foreground">
-            {forecast.propText}
-          </div>
-          <Link
-            href={`/props/${forecast.propId}`}
-            className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <ExternalLink className="h-3 w-3" />
-          </Link>
-        </div>
+        <Link
+          href={`/props/${forecast.propId}`}
+          className="block truncate text-foreground transition-colors hover:text-primary"
+        >
+          {forecast.propText}
+        </Link>
       </TableCell>
       <TableCell className="text-right font-mono tabular-nums text-foreground">
         {(forecast.forecast * 100).toFixed(1)}%


### PR DESCRIPTION
The `ExternalLink` icon (box with an arrow popping out) signals "this opens a new tab" — but we use it on several links that just navigate in place. This swaps those for plain clickable elements.

### Audited every `ExternalLink` usage

| Location | Link target | Action |
|----------|-------------|--------|
| `account/account-details.tsx` | external IDP, `target="_blank"` | ✅ **kept** — genuinely a new tab |
| `admin/users/user-name-cell.tsx` | internal `/admin/users/[id]` | removed icon; the name links on its own |
| `admin/competitions/competition-row.tsx` | internal `/competitions/[id]` | removed the redundant icon-only button; the **name** is now the link (pointed at the competition overview) |
| `scores/.../score-table-parts.tsx` | internal `/props/[id]` | removed icon; the **prop text** is now the link |

No internal links use `target="_blank"`, so there were no "opens a new tab unexpectedly" cases to fix the other way.

### One judgment call for you
`app/admin/admin-nav-card.tsx` (the `/admin` landing cards, from #146) uses an **`ArrowUpRight` (↗)** corner glyph. That's a same-tab internal nav card. `↗` leans slightly "outward" but is a common in-app "open" affordance (and isn't the literal external-link icon), so I left it. Say the word if you'd rather I switch it to `ArrowRight` (→) for consistency.

### Verification
`tsc` clean · `eslint` clean. (Pure markup/icon changes — no behavior change beyond the competition-row name now linking to the overview instead of `/forecasts`.)

https://claude.ai/code/session_017vgvYE1CFhG7kNPQ8dnTgi

---
_Generated by [Claude Code](https://claude.ai/code/session_017vgvYE1CFhG7kNPQ8dnTgi)_