### PR TITLE
Remove redundant copy on sign-in card

### DIFF
--- a/app/login/login-form-card.tsx
+++ b/app/login/login-form-card.tsx
@@ -42,16 +42,11 @@ export default function LoginFormCard({
             Sign in
           </CardTitle>
           <CardDescription>
-            Sign in with your identity provider account
+            You&apos;ll be redirected to your identity provider to continue.
           </CardDescription>
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
-        <p className="rounded-lg border bg-muted/40 p-3 text-sm text-muted-foreground">
-          You&apos;ll be redirected to sign in with your identity provider
-          account.
-        </p>
-
         <Button
           onClick={handleSignIn}
           className="h-11 w-full font-medium"


### PR DESCRIPTION
## What

The sign-in card showed the same message twice:

- **Subtitle:** "Sign in with your identity provider account"
- **Muted info box:** "You'll be redirected to sign in with your identity provider account."

This folds the only genuinely useful bit (the "you'll be redirected" expectation) into the subtitle and drops the box entirely.

## Why

The two elements arose independently — the subtitle is the standard card-description slot, and the box was a callout to signal that "Sign in" leaves the page for the OAuth provider. Together they were pure redundancy. For a single-action page, one line of context is plenty, and dropping the box reduces visual weight.

## Result

```
Sign in
You'll be redirected to your identity provider to continue.
[ Sign in ]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)