### PR TITLE
Recolor probability indicator to a single-hue indigo ramp

### DIFF
--- a/lib/forecast-colors.test.ts
+++ b/lib/forecast-colors.test.ts
@@ -10,30 +10,40 @@ describe("getProbabilityColors", () => {
     expect(c.border).toBe("border-muted-foreground/30");
   });
 
-  it("maps low probabilities to red", () => {
-    expect(getProbabilityColors(0).bar).toBe("bg-red-400");
-    expect(getProbabilityColors(0.2).bar).toBe("bg-red-400");
+  it("maps each 20% bucket to a distinct indigo bar at the boundaries", () => {
+    // ≤20
+    expect(getProbabilityColors(0).bar).toBe("bg-indigo-300 dark:bg-indigo-700");
+    expect(getProbabilityColors(0.2).bar).toBe("bg-indigo-300 dark:bg-indigo-700");
+    // ≤40
+    expect(getProbabilityColors(0.21).bar).toBe("bg-indigo-400 dark:bg-indigo-600");
+    expect(getProbabilityColors(0.4).bar).toBe("bg-indigo-400 dark:bg-indigo-600");
+    // ≤60
+    expect(getProbabilityColors(0.41).bar).toBe("bg-indigo-500 dark:bg-indigo-500");
+    expect(getProbabilityColors(0.6).bar).toBe("bg-indigo-500 dark:bg-indigo-500");
+    // ≤80
+    expect(getProbabilityColors(0.61).bar).toBe("bg-indigo-600 dark:bg-indigo-400");
+    expect(getProbabilityColors(0.8).bar).toBe("bg-indigo-600 dark:bg-indigo-400");
+    // >80
+    expect(getProbabilityColors(0.81).bar).toBe("bg-indigo-700 dark:bg-indigo-300");
+    expect(getProbabilityColors(1).bar).toBe("bg-indigo-700 dark:bg-indigo-300");
   });
 
-  it("maps each bucket to its hue at the boundaries", () => {
-    expect(getProbabilityColors(0.21).bar).toBe("bg-orange-400");
-    expect(getProbabilityColors(0.4).bar).toBe("bg-orange-400");
-    expect(getProbabilityColors(0.41).bar).toBe("bg-yellow-500");
-    expect(getProbabilityColors(0.6).bar).toBe("bg-yellow-500");
-    expect(getProbabilityColors(0.61).bar).toBe("bg-lime-500");
-    expect(getProbabilityColors(0.8).bar).toBe("bg-lime-500");
-  });
-
-  it("maps high probabilities to green", () => {
-    expect(getProbabilityColors(0.81).bar).toBe("bg-green-500");
-    expect(getProbabilityColors(1).bar).toBe("bg-green-500");
-  });
-
-  it("pairs a tinted bg with a tinted text in every bucket", () => {
+  it("uses a single indigo hue across every bucket (no stoplight ramp)", () => {
     for (const p of [0, 0.3, 0.5, 0.7, 0.95]) {
       const c = getProbabilityColors(p);
-      expect(c.bg).toMatch(/^bg-\w+-100 dark:bg-\w+-950$/);
-      expect(c.text).toMatch(/^text-\w+-700 dark:text-\w+-400$/);
+      expect(c.bg).toMatch(/^bg-indigo-\d+ dark:bg-indigo-\d+$/);
+      expect(c.text).toMatch(/^text-(indigo-\d+|white) dark:text-indigo-\d+$/);
+      expect(c.bar).toMatch(/^bg-indigo-\d+ dark:bg-indigo-\d+$/);
+      expect(c.border).toMatch(/^border-indigo-\d+ dark:border-indigo-\d+$/);
     }
+  });
+
+  it("deepens monotonically with probability (light-mode bar shade increases)", () => {
+    const shade = (p: number) =>
+      Number(getProbabilityColors(p).bar.match(/^bg-indigo-(\d+)/)![1]);
+    const shades = [0.1, 0.3, 0.5, 0.7, 0.9].map(shade);
+    const ascending = [...shades].sort((a, b) => a - b);
+    expect(shades).toEqual(ascending);
+    expect(new Set(shades).size).toBe(shades.length); // every bucket distinct
   });
 });

--- a/lib/forecast-colors.ts
+++ b/lib/forecast-colors.ts
@@ -1,10 +1,17 @@
 /**
  * Probability → color mapping for forecast surfaces.
  *
- * This is a genuine *data encoding* (low = red, high = green), the same graded
- * scale used by the `upcoming-deadlines` heatmap. Per the design language in
- * CLAUDE.md, graded scales are the sanctioned exception to the "semantic colors
- * only" rule because the color *is* information here, not decoration.
+ * This is a genuine *data encoding*, the same graded scale used by the
+ * `upcoming-deadlines` heatmap. Per the design language in CLAUDE.md, graded
+ * scales are the sanctioned exception to the "semantic colors only" rule
+ * because the color *is* information here, not decoration.
+ *
+ * The ramp is a single-hue *indigo* sequential scale (the brand hue), not a
+ * red→green diverging one: probability is a magnitude, not a good/bad axis, so
+ * a stoplight ramp both reads as garish and implies a value judgment that
+ * doesn't apply. Higher probability = more prominent indigo in *both* themes
+ * (light: pale → deep; dark: dim → bright), so the encoding survives a theme
+ * switch.
  *
  * Centralized so every probability surface (stats, distribution chart,
  * forecaster list, the competition prop view, upcoming deadlines) reads from a
@@ -24,8 +31,8 @@ export interface ProbabilityColors {
 
 /**
  * Map a probability in [0, 1] (or `null` for "no forecast") to the shared
- * heatmap color set. Buckets at 20% intervals: ≤20 red, ≤40 orange, ≤60
- * yellow, ≤80 lime, else green.
+ * indigo ramp. Buckets at 20% intervals: ≤20 palest, ≤40, ≤60, ≤80, else
+ * deepest.
  */
 export function getProbabilityColors(prob: number | null): ProbabilityColors {
   if (prob === null) {
@@ -38,40 +45,40 @@ export function getProbabilityColors(prob: number | null): ProbabilityColors {
   }
   if (prob <= 0.2) {
     return {
-      bg: "bg-red-100 dark:bg-red-950",
-      text: "text-red-700 dark:text-red-400",
-      bar: "bg-red-400",
-      border: "border-red-400",
+      bg: "bg-indigo-100 dark:bg-indigo-950",
+      text: "text-indigo-700 dark:text-indigo-300",
+      bar: "bg-indigo-300 dark:bg-indigo-700",
+      border: "border-indigo-300 dark:border-indigo-700",
     };
   }
   if (prob <= 0.4) {
     return {
-      bg: "bg-orange-100 dark:bg-orange-950",
-      text: "text-orange-700 dark:text-orange-400",
-      bar: "bg-orange-400",
-      border: "border-orange-400",
+      bg: "bg-indigo-200 dark:bg-indigo-900",
+      text: "text-indigo-800 dark:text-indigo-200",
+      bar: "bg-indigo-400 dark:bg-indigo-600",
+      border: "border-indigo-400 dark:border-indigo-600",
     };
   }
   if (prob <= 0.6) {
     return {
-      bg: "bg-yellow-100 dark:bg-yellow-950",
-      text: "text-yellow-700 dark:text-yellow-400",
-      bar: "bg-yellow-500",
-      border: "border-yellow-500",
+      bg: "bg-indigo-300 dark:bg-indigo-800",
+      text: "text-indigo-900 dark:text-indigo-100",
+      bar: "bg-indigo-500 dark:bg-indigo-500",
+      border: "border-indigo-500 dark:border-indigo-500",
     };
   }
   if (prob <= 0.8) {
     return {
-      bg: "bg-lime-100 dark:bg-lime-950",
-      text: "text-lime-700 dark:text-lime-400",
-      bar: "bg-lime-500",
-      border: "border-lime-500",
+      bg: "bg-indigo-400 dark:bg-indigo-700",
+      text: "text-indigo-950 dark:text-indigo-50",
+      bar: "bg-indigo-600 dark:bg-indigo-400",
+      border: "border-indigo-600 dark:border-indigo-400",
     };
   }
   return {
-    bg: "bg-green-100 dark:bg-green-950",
-    text: "text-green-700 dark:text-green-400",
-    bar: "bg-green-500",
-    border: "border-green-500",
+    bg: "bg-indigo-600 dark:bg-indigo-500",
+    text: "text-white dark:text-indigo-50",
+    bar: "bg-indigo-700 dark:bg-indigo-300",
+    border: "border-indigo-700 dark:border-indigo-300",
   };
 }


### PR DESCRIPTION
Follow-up to the design audit: clean up the "garish" forecast/probability indicator.

## Problem
`lib/forecast-colors.ts` used a red→orange→yellow→lime→green ramp. On the forecaster list it **triple-encoded** the same value — bar *length* + the *`%`* label + *hue* — and the stoplight colors implied a good→bad judgment that doesn't apply to a forecast probability. It read as garish and off-language.

## Change
A single-hue **indigo** sequential scale (the brand hue). Probability is a magnitude, so a sequential ramp is the right encoding; higher probability = more prominent indigo in **both** themes (light: pale→deep, dark: dim→bright), so the encoding survives a theme switch.

- Same `{bg, text, bar, border}` shape and same 20% buckets → all consumers pick it up with no changes: the **forecaster list** (`bar`), the **competition prop view** (`bg`/`text`/`bar`/`border`), and the **upcoming-deadlines heatmap** (`bg`/`text`).
- The heatmap keeps a graded scale — still the sanctioned data-encoding exception, just on one hue now instead of a rainbow.

| bucket | before (bar) | after (bar, light) |
|---|---|---|
| ≤20% | red-400 | indigo-300 |
| ≤40% | orange-400 | indigo-400 |
| ≤60% | yellow-500 | indigo-500 |
| ≤80% | lime-500 | indigo-600 |
| >80% | green-500 | indigo-700 |

## Verification
`vitest` (4/4 pass — updated to assert the indigo buckets + monotonic deepening), `tsc --noEmit` clean, `eslint` clean. Rendered visuals land on staging once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)