### PR TITLE
Polish: navbar load pop-in + dashed-circle incomplete indicator

### DIFF
--- a/components/competition-dashboard/leaderboard-sidebar.tsx
+++ b/components/competition-dashboard/leaderboard-sidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { CompetitionScore } from "@/lib/db_actions";
+import { IncompleteIndicator } from "@/components/incomplete-indicator";
 
 interface LeaderboardEntry {
   rank: number;
@@ -26,22 +27,22 @@ function LeaderboardRow({ entry }: LeaderboardRowProps) {
         <span className="w-4 shrink-0 text-right font-mono text-xs tabular-nums text-muted-foreground">
           {entry.rank}
         </span>
-        <span
-          className={cn(
-            "truncate text-sm text-foreground",
-            emphasized ? "font-semibold" : "font-medium",
-          )}
-        >
-          {entry.userName}
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span
+            className={cn(
+              "truncate text-sm text-foreground",
+              emphasized ? "font-semibold" : "font-medium",
+            )}
+          >
+            {entry.userName}
+          </span>
           {entry.isCurrentUser && (
-            <span className="ml-1 text-xs font-normal text-primary">you</span>
-          )}
-          {entry.isIncomplete && (
-            <span className="ml-1.5 text-xs font-normal text-muted-foreground">
-              incomplete
+            <span className="shrink-0 text-xs font-normal text-primary">
+              you
             </span>
           )}
-        </span>
+          {entry.isIncomplete && <IncompleteIndicator />}
+        </div>
       </div>
       <span
         className={cn(

--- a/components/incomplete-indicator.tsx
+++ b/components/incomplete-indicator.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { CircleDashed } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+/**
+ * Marks a forecaster who hasn't forecasted every proposition — their score is
+ * based on a partial set. A muted dashed circle reads as "partial" at a glance;
+ * the tooltip spells it out. Render it OUTSIDE any truncating name span so it
+ * never clips.
+ */
+export function IncompleteIndicator({ className }: { className?: string }) {
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className={cn(
+              "inline-flex shrink-0 items-center text-muted-foreground",
+              className,
+            )}
+          >
+            <CircleDashed className="h-3.5 w-3.5" aria-hidden="true" />
+            <span className="sr-only">
+              Incomplete — hasn&apos;t forecasted every proposition
+            </span>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>Hasn&apos;t forecasted every proposition</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/components/landing/mini-leaderboard.tsx
+++ b/components/landing/mini-leaderboard.tsx
@@ -2,6 +2,7 @@ import { getCompetitionScores } from "@/lib/db_actions";
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 import { cn, focusRing } from "@/lib/utils";
+import { IncompleteIndicator } from "@/components/incomplete-indicator";
 
 interface MiniLeaderboardProps {
   competitionId: number;
@@ -61,19 +62,19 @@ export default async function MiniLeaderboard({
                 <span className="w-4 shrink-0 text-right font-mono text-xs tabular-nums text-muted-foreground">
                   {index + 1}
                 </span>
-                <span
-                  className={cn(
-                    "truncate text-sm text-foreground",
-                    isLeader ? "font-semibold" : "font-medium",
-                  )}
-                >
-                  {userScore.userName}
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span
+                    className={cn(
+                      "truncate text-sm text-foreground",
+                      isLeader ? "font-semibold" : "font-medium",
+                    )}
+                  >
+                    {userScore.userName}
+                  </span>
                   {incompleteSet.has(userScore.userId) && (
-                    <span className="ml-1.5 text-xs font-normal text-muted-foreground">
-                      incomplete
-                    </span>
+                    <IncompleteIndicator />
                   )}
-                </span>
+                </div>
               </div>
               <span
                 className={cn(

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -142,28 +142,6 @@ export default function NavBar() {
     return (link as NavLink).href !== undefined;
   }
 
-  if (isLoading) {
-    return (
-      <nav className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-        <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-5 sm:px-6 lg:px-8">
-          <div className="flex items-center space-x-4">
-            <Link
-              href="/"
-              aria-label="Forecasting home"
-              className="inline-flex items-center rounded-md px-2 py-1.5 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-            >
-              <Wordmark />
-            </Link>
-          </div>
-          <div className="flex items-center space-x-2">
-            <div className="h-9 w-9 bg-muted animate-pulse rounded-md" />
-            <div className="h-9 w-9 bg-muted animate-pulse rounded-md" />
-          </div>
-        </div>
-      </nav>
-    );
-  }
-
   return (
     <nav className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="flex h-16 items-center justify-between px-4 w-full">

--- a/components/navbar/user-status.tsx
+++ b/components/navbar/user-status.tsx
@@ -13,7 +13,6 @@ import Link from "next/link";
 import Image from "next/image";
 import { Button } from "../ui/button";
 import { useLogout } from "@/hooks/useLogout";
-import { Spinner } from "@/components/ui/spinner";
 
 export function UserStatus() {
   const { user, isLoading, error } = useCurrentUser();
@@ -75,10 +74,14 @@ export function UserStatus() {
           </DropdownMenuContent>
         </DropdownMenu>
       ) : isLoading ? (
-        <Button disabled variant="outline" size="sm">
-          <Spinner className="h-4 w-4" />
-          <span className="sr-only">Loading...</span>
-        </Button>
+        // Round, avatar-sized placeholder so it morphs into the avatar without
+        // a shape/size shift once the user resolves.
+        <div
+          role="status"
+          className="h-9 w-9 animate-pulse rounded-full bg-muted"
+        >
+          <span className="sr-only">Loading…</span>
+        </div>
       ) : (
         <Link href="/login">
           <Button size="sm">Log in</Button>

--- a/components/scores/leaderboard.tsx
+++ b/components/scores/leaderboard.tsx
@@ -2,10 +2,11 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { ChevronDown, Info } from "lucide-react";
+import { ChevronDown, CircleDashed, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Category } from "@/types/db_types";
 import type { CompetitionScore, UserCategoryScore } from "@/lib/db_actions";
+import { IncompleteIndicator } from "@/components/incomplete-indicator";
 
 // Logarithmic scale: emphasizes differences at the good (low) end.
 // log(1 + score*9) maps 0→0 and 1→1, but with log compression, giving more
@@ -67,7 +68,7 @@ function ScoreRow({
         </div>
 
         {/* Name */}
-        <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 flex-1 items-center gap-1.5">
           <span
             className={cn(
               "truncate text-foreground",
@@ -75,15 +76,11 @@ function ScoreRow({
             )}
           >
             {user.userName}
-            {user.isCurrentUser && (
-              <span className="ml-1 text-sm font-normal text-primary">you</span>
-            )}
-            {user.isIncomplete && (
-              <span className="ml-1.5 text-sm font-normal text-muted-foreground">
-                incomplete
-              </span>
-            )}
           </span>
+          {user.isCurrentUser && (
+            <span className="shrink-0 text-sm font-normal text-primary">you</span>
+          )}
+          {user.isIncomplete && <IncompleteIndicator />}
         </div>
 
         {/* Score bar */}
@@ -291,13 +288,11 @@ export default function Leaderboard({
               <div className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
                 {["1st", "2nd", "3rd"][i]}
               </div>
-              <div className="mt-1 truncate text-sm font-medium text-foreground">
-                {user.userName}
-                {user.isIncomplete && (
-                  <span className="ml-1 text-xs font-normal text-muted-foreground">
-                    incomplete
-                  </span>
-                )}
+              <div className="mt-1 flex items-center justify-center gap-1.5">
+                <span className="truncate text-sm font-medium text-foreground">
+                  {user.userName}
+                </span>
+                {user.isIncomplete && <IncompleteIndicator />}
               </div>
               <div className="mt-1 font-mono text-lg font-semibold tabular-nums text-foreground">
                 {user.score.toFixed(3)}
@@ -333,8 +328,9 @@ export default function Leaderboard({
 
       {/* Footnote for incomplete users */}
       {scores.incompleteUserIds.length > 0 && (
-        <p className="text-xs text-muted-foreground">
-          Users marked incomplete have not forecasted all propositions.
+        <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <CircleDashed className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          Marks forecasters who haven&apos;t forecasted every proposition.
         </p>
       )}
     </div>


### PR DESCRIPTION
The last two items from the design audit.

## 1. Navbar load pop-in
While `useCurrentUser()` loaded, `navbar.tsx` early-returned a skeleton with **two grey pulsing boxes** standing in for the theme toggle and avatar, then swapped them for the real controls — a visible pop. The theme toggle has no dependency on the user, so it never needed to wait.

- Dropped the blanket skeleton; the navbar always renders, so `<ThemeToggle/>` appears immediately.
- `UserStatus` keeps its own loading state, now a **round, avatar-sized** placeholder that morphs into the avatar without a shape/size shift (it was a square `rounded-md` box before).

## 2. "incomplete" → dashed-circle indicator
The `incomplete` label lived *inside* the truncating name span, so narrow rows clipped it ("Akshay Rangesh incom…"). Replaced the word with a shared **`<IncompleteIndicator/>`** — a muted dashed-circle icon (`CircleDashed`, reads as "partial") with a tooltip "Hasn't forecasted every proposition", rendered **outside** the name span so it can never truncate.

Applied across all four surfaces (home standings, competition sidebar, full leaderboard rows + podium); the footnote now shows the same icon.

## Verification
`tsc --noEmit` clean, `eslint` clean, full unit suite green (214 passed / 9 skipped). Verified the indicator + tooltip visually in Storybook (`Competition/LeaderboardSidebar`) — icon renders cleanly, no clipping, tooltip reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)