### PR TITLE
Build a single environment-agnostic image

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -39,4 +39,4 @@ jobs:
           NODE_ENV: production
           DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
           IDP_BASE_URL: http://dummy
-          NEXT_PUBLIC_IDP_BASE_URL: http://dummy
+          IDP_PUBLIC_URL: http://dummy

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,11 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# Build-time args for NEXT_PUBLIC_ vars and Sentry source maps
-ARG NEXT_PUBLIC_IDP_BASE_URL
+# Build-time args for Sentry source maps
 ARG SENTRY_ORG
 ARG SENTRY_PROJECT
 ARG SENTRY_AUTH_TOKEN
 
-ENV NEXT_PUBLIC_IDP_BASE_URL=$NEXT_PUBLIC_IDP_BASE_URL
 ENV SENTRY_ORG=$SENTRY_ORG
 ENV SENTRY_PROJECT=$SENTRY_PROJECT
 ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
@@ -23,6 +21,7 @@ ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 # data collection, but doesn't actually connect to anything.
 ENV DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy"
 ENV IDP_BASE_URL="http://dummy"
+ENV IDP_PUBLIC_URL="http://dummy"
 
 RUN npm run build
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,8 +2,6 @@ options:
   logging: CLOUD_LOGGING_ONLY
 
 substitutions:
-  _NEXT_PUBLIC_IDP_BASE_URL_PROD: 'https://identity.ethanswan.com'
-  _NEXT_PUBLIC_IDP_BASE_URL_STAGING: 'https://identity-staging.tailc06f30.ts.net'
   _SENTRY_ORG: 'forecasting'
   _SENTRY_PROJECT: 'forecasting-app'
   _IMAGE: 'us-central1-docker.pkg.dev/ethans-services/containers/forecasting'
@@ -14,45 +12,25 @@ availableSecrets:
       env: 'SENTRY_AUTH_TOKEN'
 
 steps:
-  # Build prod image (with BuildKit layer caching to avoid re-running npm ci)
-  - id: 'build-prod'
-    name: 'gcr.io/cloud-builders/docker'
-    waitFor: ['-']
-    entrypoint: 'bash'
+  # Single environment-agnostic image, consumed by both staging and prod.
+  # The IDP URL that used to differ per env is read at runtime from the K8s
+  # configmap (IDP_PUBLIC_URL), so there's no build-time difference between envs.
+  # BuildKit layer cache persists to a `buildcache` tag (mode=max) since Cloud
+  # Build workers are ephemeral and would otherwise start cold every time.
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
     args:
-      - '-c'
+      - -c
       - |
-        docker buildx create --use --name builder-prod
+        docker buildx create --use --driver docker-container
         docker buildx build \
-          --cache-from type=registry,ref=${_IMAGE}:cache-prod \
-          --cache-to type=registry,ref=${_IMAGE}:cache-prod,mode=max \
-          --push \
-          --build-arg NEXT_PUBLIC_IDP_BASE_URL=${_NEXT_PUBLIC_IDP_BASE_URL_PROD} \
+          --cache-from type=registry,ref=${_IMAGE}:buildcache \
+          --cache-to type=registry,ref=${_IMAGE}:buildcache,mode=max \
           --build-arg SENTRY_ORG=${_SENTRY_ORG} \
           --build-arg SENTRY_PROJECT=${_SENTRY_PROJECT} \
           --build-arg SENTRY_AUTH_TOKEN=$$SENTRY_AUTH_TOKEN \
-          -t ${_IMAGE}:${SHORT_SHA}-prod \
-          -t ${_IMAGE}:prod \
-          .
-    secretEnv: ['SENTRY_AUTH_TOKEN']
-  # Build staging image (with BuildKit layer caching to avoid re-running npm ci)
-  - id: 'build-staging'
-    name: 'gcr.io/cloud-builders/docker'
-    waitFor: ['-']
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        docker buildx create --use --name builder-staging
-        docker buildx build \
-          --cache-from type=registry,ref=${_IMAGE}:cache-staging \
-          --cache-to type=registry,ref=${_IMAGE}:cache-staging,mode=max \
+          -t ${_IMAGE}:${SHORT_SHA} \
+          -t ${_IMAGE}:latest \
           --push \
-          --build-arg NEXT_PUBLIC_IDP_BASE_URL=${_NEXT_PUBLIC_IDP_BASE_URL_STAGING} \
-          --build-arg SENTRY_ORG=${_SENTRY_ORG} \
-          --build-arg SENTRY_PROJECT=${_SENTRY_PROJECT} \
-          --build-arg SENTRY_AUTH_TOKEN=$$SENTRY_AUTH_TOKEN \
-          -t ${_IMAGE}:${SHORT_SHA}-staging \
-          -t ${_IMAGE}:staging \
           .
     secretEnv: ['SENTRY_AUTH_TOKEN']

--- a/k8s/argocd/image-updater.yaml
+++ b/k8s/argocd/image-updater.yaml
@@ -14,4 +14,4 @@ spec:
           imageName: us-central1-docker.pkg.dev/ethans-services/containers/forecasting
           commonUpdateSettings:
             updateStrategy: newest-build
-            allowTags: "regexp:^[a-f0-9]+-staging$"
+            allowTags: "regexp:^[a-f0-9]{7,}$"

--- a/k8s/prod/configmap-env.yaml
+++ b/k8s/prod/configmap-env.yaml
@@ -6,6 +6,6 @@ data:
   ENV: "prod"
   APP_BASE_URL: "https://forecasting.ethanswan.com"
   IDP_BASE_URL: "http://identity.identity-prod.svc.cluster.local"
-  NEXT_PUBLIC_IDP_BASE_URL: "https://identity.ethanswan.com"
+  IDP_PUBLIC_URL: "https://identity.ethanswan.com"
   PUBSUB_TOPIC: "forecasting-events-prod"
   SENTRY_DSN: "https://42fb7fde7d5842831f2324ed33c7f50f@o4509062063587328.ingest.us.sentry.io/4509062066012160"

--- a/k8s/staging/configmap-env.yaml
+++ b/k8s/staging/configmap-env.yaml
@@ -6,6 +6,6 @@ data:
   ENV: "staging"
   APP_BASE_URL: "https://forecasting-staging.tailc06f30.ts.net"
   IDP_BASE_URL: "http://identity.identity-staging.svc.cluster.local"
-  NEXT_PUBLIC_IDP_BASE_URL: "https://identity-staging.tailc06f30.ts.net"
+  IDP_PUBLIC_URL: "https://identity-staging.tailc06f30.ts.net"
   PUBSUB_TOPIC: "forecasting-events-staging"
   SENTRY_DSN: "https://42fb7fde7d5842831f2324ed33c7f50f@o4509062063587328.ingest.us.sentry.io/4509062066012160"

--- a/lib/idp/client.test.ts
+++ b/lib/idp/client.test.ts
@@ -14,7 +14,7 @@ describe("IDP Client", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.stubEnv("IDP_BASE_URL", "https://identity.example.com");
-    vi.stubEnv("NEXT_PUBLIC_IDP_BASE_URL", "https://identity.example.com");
+    vi.stubEnv("IDP_PUBLIC_URL", "https://identity.example.com");
   });
 
   describe("buildNameFromUserInfo", () => {

--- a/lib/idp/client.ts
+++ b/lib/idp/client.ts
@@ -8,9 +8,9 @@ function requiredEnv(name: string): string {
 }
 
 // IDP_BASE_URL: server-to-server calls (internal K8s URL in cluster).
-// IDP_PUBLIC_URL: browser-facing redirects and JWT issuer validation (external URL, baked at build time via NEXT_PUBLIC_IDP_BASE_URL).
+// IDP_PUBLIC_URL: browser-facing redirects and JWT issuer validation (external URL, provided at runtime via the IDP_PUBLIC_URL env var).
 const IDP_BASE_URL = requiredEnv("IDP_BASE_URL");
-const IDP_PUBLIC_URL = requiredEnv("NEXT_PUBLIC_IDP_BASE_URL");
+const IDP_PUBLIC_URL = requiredEnv("IDP_PUBLIC_URL");
 const IDP_CLIENT_ID = process.env.IDP_CLIENT_ID || "";
 const IDP_CLIENT_SECRET = process.env.IDP_CLIENT_SECRET || "";
 const IDP_ADMIN_CLIENT_ID = process.env.IDP_ADMIN_CLIENT_ID || "";


### PR DESCRIPTION
## Why

Every push to `main` built **two** Docker images — `-prod` and `-staging` — in parallel `buildx` steps, each running `npm ci` + `next build` + Sentry source-map upload and contending for CPU on the default Cloud Build worker. Measured wall-clock: **3.5–5 min** typical, **9–12 min** when `package-lock.json` changes.

The two builds were redundant. Their only difference was `--build-arg NEXT_PUBLIC_IDP_BASE_URL`, and that arg is dead weight:

- It's consumed only in `lib/idp/client.ts`, which is `import "server-only"` (never in a client bundle) — the **only** `NEXT_PUBLIC_*` var in the repo.
- It's read as `requiredEnv("NEXT_PUBLIC_IDP_BASE_URL")` → `process.env[name]`, a **dynamic** access that webpack's `NEXT_PUBLIC_*` inlining does not touch → read at **runtime**, not baked.
- The `runner` stage never sets it; the K8s configmaps already supply the real per-env value at runtime.

So both images run identically — the runtime configmap decides the IDP URL.

## What

- **One image** tagged `{sha}` + `:latest`, matching identity / fitness-api / asset_manager / bifrost (single `buildx` step, single `:buildcache`).
- Rename `NEXT_PUBLIC_IDP_BASE_URL` → **`IDP_PUBLIC_URL`** everywhere (source, test, Dockerfile dummy, both configmaps, PR workflow, local `.env*`), since the `NEXT_PUBLIC_` prefix was misleading for a server-only, runtime-read value.
- `Dockerfile`: drop the IDP build arg; add `ENV IDP_PUBLIC_URL="http://dummy"` next to the existing build-time dummies so `next build` still passes.
- `image-updater.yaml`: `allowTags` → `^[a-f0-9]{7,}$` to match the new plain-SHA scheme.

Net: roughly half the build time, tagging consistent with the other services, and `ib promote` now promotes the exact digest staging tested.

## Verification

- `tsc --noEmit` clean; `eslint` 0 errors.
- `vitest lib/idp/client.test.ts` → 8/8.
- Local `docker build .` succeeds — `next build` completes without the old arg.

## Post-merge manual steps (cluster-side)

1. `kubectl apply -f k8s/argocd/image-updater.yaml` — the CR isn't synced by an app-of-apps, so the new regex only takes effect on apply.
2. After the first new build, confirm `ib status forecasting` reads the plain `{sha}`, then `ib promote forecasting` for prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)