### PR TITLE
chore: remove unused cn import in markdown renderer

### DIFF
--- a/components/markdown.tsx
+++ b/components/markdown.tsx
@@ -1,5 +1,4 @@
 import Markdown from "markdown-to-jsx";
-import { cn } from "@/lib/utils";
 
 interface MarkdownProps {
   children: string;


### PR DESCRIPTION
`cn` was imported in `components/markdown.tsx` but never used — `className` is passed straight through to `<Markdown>`. Removing it clears the `@typescript-eslint/no-unused-vars` warning.

Doubles as a real source change to measure the first warm-cache, single-image Cloud Build (post #156).

🤖 Generated with [Claude Code](https://claude.com/claude-code)