### PR TITLE
perf(build): skip redundant lint + type-check during next build

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,17 @@ const projectRoot = dirname(fileURLToPath(import.meta.url));
 const nextConfig = {
   output: "standalone",
   outputFileTracingRoot: projectRoot,
+  // Lint and type-check already run as dedicated PR-check steps (`npm run lint`,
+  // `tsc --noEmit`) before anything merges to main, so re-running them inside
+  // `next build` during the Docker image build is redundant work. Skipping both
+  // here keeps the production build focused on compilation. `main` stays gated
+  // by the PR checks.
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
   turbopack: {
     root: projectRoot,
   },


### PR DESCRIPTION
## Why

After the single-image collapse, a typical Cloud Build is ~3 min, almost entirely one `next build`. That build re-runs a full TypeScript type-check (and ESLint) — work the **PR checks already did** (`npm run lint` + `tsc --noEmit` run before merge). Duplicated effort on every image build.

## What

`next.config.mjs`:
```js
eslint: { ignoreDuringBuilds: true },
typescript: { ignoreBuildErrors: true },
```

The production build now focuses on compilation. Type/lint safety is unchanged — `main` is still gated by the PR checks (which keep running lint + tsc as dedicated steps). Same logic already applied to "tests don't run in Cloud Build."

Measuring the warm-cache build time delta vs. the previous baseline (~3m02s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)