### PR TITLE
fix(build): drop unsupported eslint key from next.config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,14 +10,11 @@ const projectRoot = dirname(fileURLToPath(import.meta.url));
 const nextConfig = {
   output: "standalone",
   outputFileTracingRoot: projectRoot,
-  // Lint and type-check already run as dedicated PR-check steps (`npm run lint`,
-  // `tsc --noEmit`) before anything merges to main, so re-running them inside
-  // `next build` during the Docker image build is redundant work. Skipping both
-  // here keeps the production build focused on compilation. `main` stays gated
-  // by the PR checks.
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
+  // `tsc --noEmit` already runs as a dedicated PR-check step before anything
+  // merges to main, so re-running the type-check inside `next build` during the
+  // Docker image build is redundant work (~45s saved). Skip it; `main` stays
+  // gated by the PR checks. (Next 16 no longer runs ESLint during `next build`,
+  // and lint runs in the PR checks regardless.)
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
Follow-up to #158. Next 16 removed the `eslint` next.config key (and no longer runs ESLint during `next build`), so `eslint.ignoreDuringBuilds` did nothing except emit an `⚠ Invalid next.config.mjs options detected: Unrecognized key(s): 'eslint'` warning on every build.

Removing it. The actual build-time win (~47s, 3m02s → 2m14s) came from `typescript.ignoreBuildErrors`, which stays. Lint is still enforced by the PR checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)