### PR TITLE
chore(sentry): set release to git SHA + drop deprecated disableLogger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,12 @@ COPY . .
 ARG SENTRY_ORG
 ARG SENTRY_PROJECT
 ARG SENTRY_AUTH_TOKEN
+ARG SENTRY_RELEASE
 
 ENV SENTRY_ORG=$SENTRY_ORG
 ENV SENTRY_PROJECT=$SENTRY_PROJECT
 ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
+ENV SENTRY_RELEASE=$SENTRY_RELEASE
 
 # Dummy values for build — Next.js evaluates server-side modules during page
 # data collection, but doesn't actually connect to anything.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,6 +29,7 @@ steps:
           --build-arg SENTRY_ORG=${_SENTRY_ORG} \
           --build-arg SENTRY_PROJECT=${_SENTRY_PROJECT} \
           --build-arg SENTRY_AUTH_TOKEN=$$SENTRY_AUTH_TOKEN \
+          --build-arg SENTRY_RELEASE=${SHORT_SHA} \
           -t ${_IMAGE}:${SHORT_SHA} \
           -t ${_IMAGE}:latest \
           --push \

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -53,6 +53,12 @@ export default withSentryConfig(nextConfig, {
   // side errors will fail.
   tunnelRoute: "/monitoring",
 
-  // Automatically tree-shake Sentry logger statements to reduce bundle size
-  disableLogger: true,
+  // Associate uploaded source maps + runtime events with the git SHA so Sentry
+  // can do release tracking (regressions, "first seen in release X"). Provided at
+  // build time via Cloud Build's SHORT_SHA (matches the deployed image tag);
+  // absent for local builds, where Sentry auto-detects. Symbolication itself runs
+  // off debug IDs and does not depend on this.
+  ...(process.env.SENTRY_RELEASE && {
+    release: { name: process.env.SENTRY_RELEASE },
+  }),
 });


### PR DESCRIPTION
Small follow-ups after confirming the app is already on Turbopack (Next 16 default) and Sentry source maps upload correctly as debug-ID artifact bundles.

## Changes
- **Set a real Sentry release.** Uploaded artifact bundles were associating to release `"undefined"` — `.git` is in `.dockerignore`, so the SDK couldn't auto-detect one. This wires `SENTRY_RELEASE=${SHORT_SHA}` (matches the deployed image tag) through `cloudbuild.yaml` → `Dockerfile` → `next.config.mjs` (`release.name`), so Sentry gets proper release tracking (regressions, "first seen in release X", release health). Conditional — falls back to Sentry auto-detection when `SENTRY_RELEASE` is unset (local/PR builds).
- **Remove `disableLogger: true`.** Deprecated and unsupported under Turbopack (Next 16); it only emitted a `DEPRECATION WARNING` on every build.

## Notes
- **Symbolication is unaffected** by the release change — it runs off debug IDs, which were already working. This only improves release *grouping/tracking*.
- The `path.join(process.cwd(), …)` Turbopack build warning originates in a **dependency** (Next.js internals), not our code, so it's intentionally left alone.

## Verify after merge
Re-query the newest artifact bundle's association — it should change from `release: "undefined"` to the commit's short SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)